### PR TITLE
Changes to main page README.MD to apply to AEON

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2018, The Monero Project
+Copyright (c) 2014-2018 , AEON , The Monero Project
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ https://github.com/aeonix/aeon/tree/v0.12.0.0#dependencies
 Run these commands:
 
 git clone --recursive https://github.com/aeonix/aeon.git aeon_sophia 
+
 cd aeon_sophia
+
 make release
 
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,14 @@ The output of `mdb_stat -ea <path to blockchain dir>` will indicate inconsistenc
 The output of `mdb_dump -s blocks <path to blockchain dir>` and `mdb_dump -s block_info <path to blockchain dir>` is useful for indicating whether blocks and block_info contain the same keys.
 These records are dumped as hex data, where the first line is the key and the second line is the data.
 
+# TIPS FOR USE
+
+Fast syncing of blockchain:
+     - Run this command after aeond (  --block-sync-size 1000 --max-concurrency 15  )
+     
+     
+
+
 ------------------------------------------------------------------------------------------------------------
 
 # License & Legal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # AEON
-
-Copyright (c) 2014-2018 The AEON Project.   
-Portions Copyright (c) 2012-2018 The Cryptonote developers.
+ 
 
 # Development resources
 
 - Web: [http://aeon.cash](http://aeon.cash)
 - GitHub:  [https://github.com/aeonix/aeon-rebase](https://github.com/aeonix/aeon-rebase)
-- IRC: [#AEON on Freenode](http://webchat.freenode.net/?randomnick=1&channels=%23AEON&prompt=1&uio=d4)
+- Reddit: [https://reddit.com/r/aeon
+- IRC: [#AEON on Freenode](http://webchat.freenode.net/?yourusername=1&channels=%23AEON&prompt=1&uio=d4)
 
 # Introduction
 
@@ -89,43 +88,6 @@ AEON is a 100% community-sponsored endeavor. If you want to join our efforts, th
 
 - MONERO [Vulnerability Response Process](https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md) encourages responsible disclosure
 - MONERO is also available via [HackerOne](https://hackerone.com/monero)
-
-# License
-
-Copyright (c) 2014-2018, #AEON , The AEON Project
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Parts of the project are originally copyright (c) 2012-2013 The Cryptonote developers
-
-# Other License Information:
-
-Copyright (c) 2014-2018, The Monero Project
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Parts of the project are originally copyright (c) 2012-2013 The Cryptonote developers
-
 
 # Dependencies Needed For Building 
 
@@ -225,6 +187,8 @@ mkdir build cd build cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="c:\folder\t
 
 If you don't have your path environment variable configured with the VS paths, you may may want to run 'C:\program files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat' (or equivalent) to temporarily set the environment variables.
 
+Please note that if using a newer version of MSVC please subsitute -G "Visual Studio 12 Win64" and subsequent file paths with correct version for proper compiling.
+
 Building Documentation
 
 AEON developer documentation uses Doxygen, and is currently a work-in-progress.
@@ -240,7 +204,6 @@ The output will be built in doc/html/
 [^] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must
 build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libg* /usr/lib/ ```
 
-------------------------------------------------------
 
 # LMDB
 
@@ -253,5 +216,42 @@ There is an `mdb_stat` command in the LMDB source that can print statistics abou
 The output of `mdb_stat -ea <path to blockchain dir>` will indicate inconsistencies in the blocks, block_heights and block_info table.
 
 The output of `mdb_dump -s blocks <path to blockchain dir>` and `mdb_dump -s block_info <path to blockchain dir>` is useful for indicating whether blocks and block_info contain the same keys.
-
 These records are dumped as hex data, where the first line is the key and the second line is the data.
+
+------------------------------------------------------------------------------------------------------------
+
+# License & Legal
+
+Copyright (c) 2014-2018, AEON , The Monero Project
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Parts of the project are originally copyright (c) 2012-2013 The Cryptonote developers
+
+# Other License Information:
+
+Copyright (c) 2014-2018, The Monero Project
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Parts of the project are originally copyright (c) 2012-2013 The Cryptonote developers

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ Portions Copyright (c) 2012-2018 The Cryptonote developers.
 - GitHub:  [https://github.com/aeonix/aeon-rebase](https://github.com/aeonix/aeon-rebase)
 - IRC: [#AEON on Freenode](http://webchat.freenode.net/?randomnick=1&channels=%23AEON&prompt=1&uio=d4)
 
-# Vulnerability response
-- Please direct vulnerabilities to the MONERO dev team via:
-
-- MONERO [Vulnerability Response Process](https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md) encourages responsible disclosure
-- MONERO is also available via [HackerOne](https://hackerone.com/monero)
-
 # Introduction
 
 AEON is a private, secure, untraceable currency. You are your bank, you control your funds, and nobody can trace your transfers.
@@ -24,6 +18,36 @@ Privacy: AEON uses a cryptographically sound system to allow you to send and rec
 Security: Using the power of a distributed peer-to-peer consensus network, every transaction on the network is cryptographically secured. Individual wallets have a 24 word mnemonic that is only displayed once, and can be written down to backup the wallet. Wallet files are encrypted with a passphrase to ensure they are useless if stolen.
 
 Untraceability: By taking advantage of ring signatures, a special property of certain types of cryptography, AEON is able to ensure that transactions are not only untraceable, but have an optional measure of ambiguity that ensures that transactions cannot easily be tied back to an individual user or computer.
+
+# How is AEON different from Monero?
+
+Compared to our CryptoNote big brother, here are AEON's main advantages:
+
+1:
+Mobile-friendly
+
+1 MB scratchpad allows AEON to run efficiently on mobile devices alongside regular laptops and desktops.
+
+2:
+Different proof-of-work
+
+AEON's lightweight PoW (CryptoNote-Lite) allows for faster verification of the blockchain.
+
+3:
+Blockchain pruning for scalability
+
+Pruning allows the blockchain to stay small and not outgrow devices with limited storage. This feature also improves anonymity by reducing age-based attacks.
+
+4:
+Fast syncing
+
+Compared to Bitcoin variants, CryptoNote coins typically have higher verification, leading to more orphaned blocks. AEON helps this issue by using a 4-minute blocktime, reducing sync by a factor of four. Coupled with our lighter PoW, sync times on lower end devices can be improved by 10x or more.
+
+5:
+Optional lightweight transfers
+
+Overall, AEON seeks to be a lightweight-Monero, similar to how Litecoin seeks to be a lightweight-Bitcoin. While still drawing from the technical advantages of Monero and CryptoNote, AEON has distinct development goals and an independent community that enable it to thrive as its own currency
+
 
 # About this Project
 
@@ -42,7 +66,7 @@ AEON uses a cryptographically sound system to allow you to send and receive fund
 When running the daemon, take care to ensure that the console output is not blocked, as this may in turn cause processing threads to be blocked, potentially resulting in unreliable operation of the daemon. This can occur because the implementation contains many logging statements which send output to the console within the context of the processing thread, and if the output buffer fills up this will block the thread. The best practice is to start the daemon within the context of a background process manager such as screen or tmux, or within a terminal window on a physical or virtual console. In doing so be sure that the session is not left in 'scrollback' or 'edit' mode as this may eventualy cause the output to block.
 To ensure reliable performance (especially on mining/pool nodes where poor performance can result in increase 'orphan blocks'), ensure that the daemon is being run on hardware with sufficient memory to avoid excessive swapping and long pauses. While it is possible to operate with limited memory and swap in some cases (though not recommended for mining), this requires care and a platform with sufficient I/O performance (e.g. unthrottled SSD). In the latter case also see the next item.
 One cause of high resource usage and long processing delays is the periodic saving of the blockchain every 12 hours. Doing so requires access to the entire memory space and potentially large amounts of swapping. It can be disabled using the --disable-save option. The blockchain will still be saved on exit or upon request using the save command.
-If using the rpc wallet (simplewallet --rpc-bind-port), access to the wallet RPC port will allow sending funds from the wallet. By default the rpc port is bound to the loopback interface so access is only possible from the same system. You are responsible for appropriately controlling/limiting access to the port (eg. using virtualization, firewall settings, etc.) to prevent loss of funds. If not using the --rpc-bind-port the wallet does not accept remote commands and this issue does not apply.
+If using the rpc wallet (aeon-wallet-cli.exe --rpc-bind-port), access to the wallet RPC port will allow sending funds from the wallet. By default the rpc port is bound to the loopback interface so access is only possible from the same system. You are responsible for appropriately controlling/limiting access to the port (eg. using virtualization, firewall settings, etc.) to prevent loss of funds. If not using the --rpc-bind-port the wallet does not accept remote commands and this issue does not apply.
 
 # Security
 
@@ -59,6 +83,12 @@ If you have a fix or code change, feel free to submit it as a pull request direc
 # Supporting the project
 
 AEON is a 100% community-sponsored endeavor. If you want to join our efforts, the easiest thing you can do is support the project financially. Both AEON and Bitcoin donations can be made to the DEV fund donation address via the `donate` command (type `help` in the command-line wallet for details).
+
+# Vulnerability response
+- Please direct vulnerabilities to the MONERO dev team via:
+
+- MONERO [Vulnerability Response Process](https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md) encourages responsible disclosure
+- MONERO is also available via [HackerOne](https://hackerone.com/monero)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -122,29 +122,60 @@ library archives (`.a`).
 
 # Compiling AEON
 
-On Unix and Linux:
+[^] On Debian/Ubuntu libgtest-dev only includes sources and headers. You must build the library binary manually. This can be done with the following command sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libg* /usr/lib/
 
-Dependencies: GCC 4.7.3 or later, CMake 2.8.6 or later, and Boost 1.53 or later (except 1.54, more details here: http://goo.gl/RrCFmA).
+Cloning the repository
 
-To build, change to the root of the source code directory, and run 'make'.
+Clone recursively to pull-in needed submodule(s):
 
-The resulting executables can be found in build/release/src.
+$ git clone --recursive https://github.com/aeonix/aeon
 
-Advanced options:
+If you already have a repo cloned, initialize and update:
 
-Parallel build: run 'make -j' instead of 'make'.
+$ cd monero && git submodule init && git submodule update
 
-Debug build: run 'make build-debug'.
+Build instructions
 
-Test suite: run 'make test-release' to run tests in addition to building. Running 'make test-debug' will do the same to the debug version.
+Aeon uses the CMake build system and a top-level Makefile that invokes cmake commands as needed.
 
-Building with Clang: it may be possible to use Clang instead of GCC, but this may not work everywhere. To build, run 'export CC=clang CXX=clang++' before running 'make'.
+On Linux and OS X
 
-Manual Cmake: If you wish to manually invoke cmake separately instead of the above make, you will need to use the following: mkdir -p build/release && cd build/release && cmake -D CMAKE_BUILD_TYPE=Release ../.. && make. Other options can be used for debug or test builds. See root Makefile in the repo.
+Install the dependencies
 
+Change to the root of the source code directory and build:
+
+  cd aeon
+  make
+Optional: If your machine has several cores and enough memory, enable parallel build by running make -j<number of threads> instead of make. For this to be worthwhile, the machine should have one core and about 2GB of RAM available per thread.
+
+Note: If cmake can not find zmq.hpp file on OS X, installing zmq.hpp from https://github.com/zeromq/cppzmq to /usr/local/include should fix that error.
+
+The resulting executables can be found in build/release/bin
+
+Add PATH="$PATH:$HOME/aeon/build/release/bin" to .profile
+
+Run Monero with aeond --detach
+
+Optional: build and run the test suite to verify the binaries:
+
+  make release-test
+NOTE: core_tests test may take a few hours to complete.
+
+Optional: to build binaries suitable for debugging:
+
+   make debug
+Optional: to build statically-linked binaries:
+
+   make release-static
+Dependencies need to be built with -fPIC. Static libraries usually aren't, so you may have to build them yourself with -fPIC. Refer to their documentation for how to build them.
+
+Optional: build documentation in doc/html (omit HAVE_DOT=YES if graphviz is not installed):
+
+  HAVE_DOT=YES doxygen Doxyfile
+  
 # On OS X:
 
-Successful Build with Cmake on High Sierra requires the following:
+Successful Build on High Sierra requires the following:
 
 1-Install osx Command Line Tools;
 Copy paste in terminal: xcode-select --install
@@ -217,6 +248,18 @@ If you are on a 32-bit system, run:
   make release-static-win32
 
 The resulting executables can be found in build/release/bin
+
+# Ubuntu 16.04
+
+Check for dependencies: 
+
+https://github.com/aeonix/aeon/tree/v0.12.0.0#dependencies
+
+Run these commands:
+
+git clone --recursive https://github.com/aeonix/aeon.git aeon_sophia 
+cd aeon_sophia
+make release
 
 
 # LMDB

--- a/README.md
+++ b/README.md
@@ -1,159 +1,103 @@
-# Monero
+# AEON
 
-Copyright (c) 2014-2018 The Monero Project.   
-Portions Copyright (c) 2012-2013 The Cryptonote developers.
+Copyright (c) 2014-2018 The AEON Project.   
+Portions Copyright (c) 2012-2018 The Cryptonote developers.
 
-## Development resources
+# Development resources
 
-- Web: [getmonero.org](https://getmonero.org)
-- Forum: [forum.getmonero.org](https://forum.getmonero.org)
-- Mail: [dev@getmonero.org](mailto:dev@getmonero.org)
-- GitHub: [https://github.com/monero-project/monero](https://github.com/monero-project/monero)
-- IRC: [#monero-dev on Freenode](http://webchat.freenode.net/?randomnick=1&channels=%23monero-dev&prompt=1&uio=d4)
+- Web: [http://aeon.cash](http://aeon.cash)
+- GitHub:  [https://github.com/aeonix/aeon-rebase](https://github.com/aeonix/aeon-rebase)
+- IRC: [#AEON on Freenode](http://webchat.freenode.net/?randomnick=1&channels=%23AEON&prompt=1&uio=d4)
 
-## Vulnerability response
+# Vulnerability response
+- Please direct vulnerabilities to the MONERO dev team via:
 
-- Our [Vulnerability Response Process](https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md) encourages responsible disclosure
-- We are also available via [HackerOne](https://hackerone.com/monero)
+- MONERO [Vulnerability Response Process](https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md) encourages responsible disclosure
+- MONERO is also available via [HackerOne](https://hackerone.com/monero)
 
-## Build
+# Introduction
 
-| Operating System      | Processor | Status |
-| --------------------- | -------- |--------|
-| Ubuntu 16.04          |  i686    | [![Ubuntu 16.04 i686](https://build.getmonero.org/png?builder=monero-static-ubuntu-i686)](https://build.getmonero.org/builders/monero-static-ubuntu-i686)
-| Ubuntu 16.04          |  amd64   | [![Ubuntu 16.04 amd64](https://build.getmonero.org/png?builder=monero-static-ubuntu-amd64)](https://build.getmonero.org/builders/monero-static-ubuntu-amd64)
-| Ubuntu 16.04          |  armv7   | [![Ubuntu 16.04 armv7](https://build.getmonero.org/png?builder=monero-static-ubuntu-arm7)](https://build.getmonero.org/builders/monero-static-ubuntu-arm7)
-| Debian Stable         |  armv8   | [![Debian armv8](https://build.getmonero.org/png?builder=monero-static-debian-armv8)](https://build.getmonero.org/builders/monero-static-debian-armv8)
-| OSX 10.10             |  amd64   | [![OSX 10.10 amd64](https://build.getmonero.org/png?builder=monero-static-osx-10.10)](https://build.getmonero.org/builders/monero-static-osx-10.10)
-| OSX 10.11             |  amd64   | [![OSX 10.11 amd64](https://build.getmonero.org/png?builder=monero-static-osx-10.11)](https://build.getmonero.org/builders/monero-static-osx-10.11)
-| OSX 10.12             |  amd64   | [![OSX 10.12 amd64](https://build.getmonero.org/png?builder=monero-static-osx-10.12)](https://build.getmonero.org/builders/monero-static-osx-10.12)
-| FreeBSD 11            |  amd64   | [![FreeBSD 11 amd64](https://build.getmonero.org/png?builder=monero-static-freebsd64)](https://build.getmonero.org/builders/monero-static-freebsd64)
-| DragonFly BSD 4.6     |  amd64   | [![DragonFly BSD amd64](https://build.getmonero.org/png?builder=monero-static-dragonflybsd-amd64)](https://build.getmonero.org/builders/monero-static-dragonflybsd-amd64)
-| Windows (MSYS2/MinGW) |  i686    | [![Windows (MSYS2/MinGW) i686](https://build.getmonero.org/png?builder=monero-static-win32)](https://build.getmonero.org/builders/monero-static-win32)
-| Windows (MSYS2/MinGW) |  amd64   | [![Windows (MSYS2/MinGW) amd64](https://build.getmonero.org/png?builder=monero-static-win64)](https://build.getmonero.org/builders/monero-static-win64)
+AEON is a private, secure, untraceable currency. You are your bank, you control your funds, and nobody can trace your transfers.
 
-## Coverage
+Privacy: AEON uses a cryptographically sound system to allow you to send and receive funds without your transactions being easily revealed on the blockchain (the ledger of transactions that everyone has). This ensures that your purchases, receipts, and all transfers remain absolutely private by default.
 
-| Type      | Status |
-|-----------|--------|
-| Coverity  | [![Coverity Status](https://scan.coverity.com/projects/9657/badge.svg)](https://scan.coverity.com/projects/9657/)
-| Coveralls | [![Coveralls Status](https://coveralls.io/repos/github/monero-project/monero/badge.svg?branch=master)](https://coveralls.io/github/monero-project/monero?branch=master)
-| License   | [![License](https://img.shields.io/badge/license-BSD3-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+Security: Using the power of a distributed peer-to-peer consensus network, every transaction on the network is cryptographically secured. Individual wallets have a 24 word mnemonic that is only displayed once, and can be written down to backup the wallet. Wallet files are encrypted with a passphrase to ensure they are useless if stolen.
 
-## Introduction
+Untraceability: By taking advantage of ring signatures, a special property of certain types of cryptography, AEON is able to ensure that transactions are not only untraceable, but have an optional measure of ambiguity that ensures that transactions cannot easily be tied back to an individual user or computer.
 
-Monero is a private, secure, untraceable, decentralised digital currency. You are your bank, you control your funds, and nobody can trace your transfers unless you allow them to do so.
+# About this Project
 
-**Privacy:** Monero uses a cryptographically sound system to allow you to send and receive funds without your transactions being easily revealed on the blockchain (the ledger of transactions that everyone has). This ensures that your purchases, receipts, and all transfers remain absolutely private by default.
+This is the core implementation of AEON. It is open source and completely free to use without restrictions, except for those specified in the license agreement below. There are no restrictions on anyone creating an alternative implementation of AEON that uses the protocol and network in a compatible manner.
 
-**Security:** Using the power of a distributed peer-to-peer consensus network, every transaction on the network is cryptographically secured. Individual wallets have a 25 word mnemonic seed that is only displayed once, and can be written down to backup the wallet. Wallet files are encrypted with a passphrase to ensure they are useless if stolen.
+As with many development projects, the repository on Github is considered to be the "staging" area for the latest changes. Before changes are merged into that master repo, they are tested by individual developers, as well as contributors who focus on thorough testing and code reviews. That having been said, the repository should be carefully considered before using it in a production environment, unless there is a patch in the repository for a particular show-stopping issue you are experiencing. It is generally a better idea to use a tagged release for stability.
 
-**Untraceability:** By taking advantage of ring signatures, a special property of a certain type of cryptography, Monero is able to ensure that transactions are not only untraceable, but have an optional measure of ambiguity that ensures that transactions cannot easily be tied back to an individual user or computer.
+Anyone is able to contribute to AEON. If you have a fix or code change, feel free to submit is as a pull request. In cases where the change is relatively small or does not affect other parts of the codebase it may be merged in immediately by any one of the collaborators. On the other hand, if the change is particularly large or complex, it is expected that it will be discussed at length either well in advance of the pull request being submitted, or even directly on the pull request.
 
-## About this project
+# Privacy
 
-This is the core implementation of Monero. It is open source and completely free to use without restrictions, except for those specified in the license agreement below. There are no restrictions on anyone creating an alternative implementation of Monero that uses the protocol and network in a compatible manner.
+AEON uses a cryptographically sound system to allow you to send and receive funds without your transactions being easily revealed on the blockchain (the ledger of transactions that everyone has). This ensures that your purchases, receipts, and all transfers remain absolutely private by default.
 
-As with many development projects, the repository on Github is considered to be the "staging" area for the latest changes. Before changes are merged into that branch on the main repository, they are tested by individual developers in their own branches, submitted as a pull request, and then subsequently tested by contributors who focus on testing and code reviews. That having been said, the repository should be carefully considered before using it in a production environment, unless there is a patch in the repository for a particular show-stopping issue you are experiencing. It is generally a better idea to use a tagged release for stability.
+# Deployment Notes
 
-**Anyone is welcome to contribute to Monero's codebase!** If you have a fix or code change, feel free to submit it as a pull request directly to the "master" branch. In cases where the change is relatively small or does not affect other parts of the codebase it may be merged in immediately by any one of the collaborators. On the other hand, if the change is particularly large or complex, it is expected that it will be discussed at length either well in advance of the pull request being submitted, or even directly on the pull request.
+When running the daemon, take care to ensure that the console output is not blocked, as this may in turn cause processing threads to be blocked, potentially resulting in unreliable operation of the daemon. This can occur because the implementation contains many logging statements which send output to the console within the context of the processing thread, and if the output buffer fills up this will block the thread. The best practice is to start the daemon within the context of a background process manager such as screen or tmux, or within a terminal window on a physical or virtual console. In doing so be sure that the session is not left in 'scrollback' or 'edit' mode as this may eventualy cause the output to block.
+To ensure reliable performance (especially on mining/pool nodes where poor performance can result in increase 'orphan blocks'), ensure that the daemon is being run on hardware with sufficient memory to avoid excessive swapping and long pauses. While it is possible to operate with limited memory and swap in some cases (though not recommended for mining), this requires care and a platform with sufficient I/O performance (e.g. unthrottled SSD). In the latter case also see the next item.
+One cause of high resource usage and long processing delays is the periodic saving of the blockchain every 12 hours. Doing so requires access to the entire memory space and potentially large amounts of swapping. It can be disabled using the --disable-save option. The blockchain will still be saved on exit or upon request using the save command.
+If using the rpc wallet (simplewallet --rpc-bind-port), access to the wallet RPC port will allow sending funds from the wallet. By default the rpc port is bound to the loopback interface so access is only possible from the same system. You are responsible for appropriately controlling/limiting access to the port (eg. using virtualization, firewall settings, etc.) to prevent loss of funds. If not using the --rpc-bind-port the wallet does not accept remote commands and this issue does not apply.
 
-## Supporting the project
+# Security
 
-Monero is a 100% community-sponsored endeavor. If you want to join our efforts, the easiest thing you can do is support the project financially. Both Monero and Bitcoin donations can be made to **donate.getmonero.org** if using a client that supports the [OpenAlias](https://openalias.org) standard. Alternatively you can send XMR to the Monero donation address via the `donate` command (type `help` in the command-line wallet for details).
+Using the power of a distributed peer-to-peer consensus network, every transaction on the network is cryptographically secured. Individual wallets have a 26 word mnemonic seed that is only displayed once, and can be written down to backup the wallet. Wallet files are encrypted with a passphrase to ensure they are useless if stolen.
 
-The Monero donation address is: `44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A` (viewkey: `f359631075708155cc3d92a32b75a7d02a5dcf27756707b47a2b31b21c389501`)
+# Untraceability
 
-The Bitcoin donation address is: `1KTexdemPdxSBcG55heUuTjDRYqbC5ZL8H`
+By taking advantage of ring signatures, a special property of a certain type of cryptography, AEON is able to ensure that transactions are not only untraceable, but have an optional measure of ambiguity that ensures that transactions cannot easily be tied back to an individual user or computer. The higher the Ring size, the more untraceable AEON is.
 
-Core development funding and/or some supporting services are also graciously provided by sponsors:
+# Anyone is welcome to contribute to AEON's codebase
 
-[<img width="80" src="https://static.getmonero.org/images/sponsors/mymonero.png"/>](https://mymonero.com)
-[<img width="150" src="https://static.getmonero.org/images/sponsors/kitware.png?1"/>](http://kitware.com)
-[<img width="100" src="https://static.getmonero.org/images/sponsors/dome9.png"/>](http://dome9.com)
-[<img width="150" src="https://static.getmonero.org/images/sponsors/araxis.png"/>](http://araxis.com)
-[<img width="150" src="https://static.getmonero.org/images/sponsors/jetbrains.png"/>](http://www.jetbrains.com/)
-[<img width="150" src="https://static.getmonero.org/images/sponsors/navicat.png"/>](http://www.navicat.com/)
-[<img width="150" src="https://static.getmonero.org/images/sponsors/symas.png"/>](http://www.symas.com/)
+If you have a fix or code change, feel free to submit it as a pull request directly to the "master" branch. In cases where the change is relatively small or does not affect other parts of the codebase it may be merged in immediately by any one of the collaborators. On the other hand, if the change is particularly large or complex, it is expected that it will be discussed at length either well in advance of the pull request being submitted, or even directly on the pull request.
 
-There are also several mining pools that kindly donate a portion of their fees, [a list of them can be found on our Bitcointalk post](https://bitcointalk.org/index.php?topic=583449.0).
+# Supporting the project
 
-## License
+AEON is a 100% community-sponsored endeavor. If you want to join our efforts, the easiest thing you can do is support the project financially. Both AEON and Bitcoin donations can be made to the DEV fund donation address via the `donate` command (type `help` in the command-line wallet for details).
 
-See [LICENSE](LICENSE).
+# License
 
-## Contributing
+Copyright (c) 2014-2018, #AEON , The AEON Project
 
-If you want to help out, see [CONTRIBUTING](CONTRIBUTING.md) for a set of guidelines.
+All rights reserved.
 
-## Scheduled software upgrades
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-Monero uses a fixed-schedule software upgrade (hard fork) mechanism to implement new features. This means that users of Monero (end users and service providers) should run current versions and upgrade their software on a regular schedule. Software upgrades occur during the months of April and October. The required software for these upgrades will be available prior to the scheduled date. Please check the repository prior to this date for the proper Monero software version. Below is the historical schedule and the projected schedule for the next upgrade.
-Dates are provided in the format YYYY-MM-DD. 
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Parts of the project are originally copyright (c) 2012-2013 The Cryptonote developers
+
+# Other License Information:
+
+Copyright (c) 2014-2018, The Monero Project
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Parts of the project are originally copyright (c) 2012-2013 The Cryptonote developers
 
 
-| Software upgrade block height | Date       | Fork version | Minimum Monero version | Recommended Monero version | Details                                                                            |  
-| ------------------------------ | -----------| ----------------- | ---------------------- | -------------------------- | ---------------------------------------------------------------------------------- |
-| 1009827                        | 2016-03-22 | v2                | v0.9.4                 | v0.9.4                     | Allow only >= ringsize 3, blocktime = 120 seconds, fee-free blocksize 60 kb       |
-| 1141317                        | 2016-09-21 | v3                | v0.9.4                 | v0.10.0                    | Splits coinbase into denominations  |
-| 1220516                        | 2017-01-05 | v4                | v0.10.1                | v0.10.2.1                  | Allow normal and RingCT transactions |
-| 1288616                        | 2017-04-15 | v5                | v0.10.3.0              | v0.10.3.1                  | Adjusted minimum blocksize and fee algorithm      |
-| 1400000                        | 2017-09-16 | v6                | v0.11.0.0              | v0.11.0.0                  | Allow only RingCT transactions, allow only >= ringsize 5      |
-| 1546000                        | 2018-04-06 | v7                | v0.12.0.0              | v0.12.0.0                  | Cryptonight variant 1, ringsize >= 7, sorted inputs
-| XXXXXXX                        | 2018-10-XX | XX                | XXXXXXXXX              | XXXXXXXXX                  | X
-
-X's indicate that these details have not been determined as of commit date.
-
-## Release staging schedule and protocol
-
-Approximately three months prior to a scheduled software upgrade, a branch from Master will be created with the new release version tag. Pull requests that address bugs should then be made to both Master and the new release branch. Pull requests that require extensive review and testing (generally, optimizations and new features) should *not* be made to the release branch. 
-
-## Installing Monero from a package
-
-Packages are available for
-
-* Ubuntu and [snap supported](https://snapcraft.io/docs/core/install) systems, via a community contributed build.
-
-    snap install monero --beta
-
-Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
-
-* Arch Linux (via [AUR](https://aur.archlinux.org/)):
-  - Stable release: [`monero`](https://aur.archlinux.org/packages/monero)
-  - Bleeding edge: [`monero-git`](https://aur.archlinux.org/packages/monero-git)
-
-* Void Linux:
-
-    xbps-install -S monero
-
-* GuixSD
-
-        guix package -i monero
-
-* OS X via [Homebrew](http://brew.sh)
-
-        brew tap sammy007/cryptonight
-        brew install monero --build-from-source
-
-* Docker
-
-        # Build using all available cores
-        docker build -t monero .
-
-        # or build using a specific number of cores (reduce RAM requirement)
-        docker build --build-arg NPROC=1 -t monero .
-     
-        # either run in foreground
-        docker run -it -v /monero/chain:/root/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
-
-        # or in background
-        docker run -it -d -v /monero/chain:/root/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
-
-Packaging for your favorite distribution would be a welcome contribution!
-
-## Compiling Monero from source
-
-### Dependencies
+# Dependencies Needed For Building 
 
 The following table summarizes the tools and libraries required to build. A
 few of the libraries are also included in this repository (marked as
@@ -184,436 +128,97 @@ library archives (`.a`).
 | Doxygen      | any           | NO       | `doxygen`          | `doxygen`    | `doxygen`         | YES      | Documentation  |
 | Graphviz     | any           | NO       | `graphviz`         | `graphviz`   | `graphviz`        | YES      | Documentation  |
 
+# Compiling AEON
+
+On Unix and Linux:
+
+Dependencies: GCC 4.7.3 or later, CMake 2.8.6 or later, and Boost 1.53 or later (except 1.54, more details here: http://goo.gl/RrCFmA).
+
+To build, change to the root of the source code directory, and run 'make'.
+
+The resulting executables can be found in build/release/src.
+
+Advanced options:
+
+Parallel build: run 'make -j' instead of 'make'.
+
+Debug build: run 'make build-debug'.
+
+Test suite: run 'make test-release' to run tests in addition to building. Running 'make test-debug' will do the same to the debug version.
+
+Building with Clang: it may be possible to use Clang instead of GCC, but this may not work everywhere. To build, run 'export CC=clang CXX=clang++' before running 'make'.
+
+Manual Cmake: If you wish to manually invoke cmake separately instead of the above make, you will need to use the following: mkdir -p build/release && cd build/release && cmake -D CMAKE_BUILD_TYPE=Release ../.. && make. Other options can be used for debug or test builds. See root Makefile in the repo.
+
+# On OS X:
+
+Successful Build with Cmake on High Sierra requires the following:
+
+1-Install osx Command Line Tools;
+Copy paste in terminal: xcode-select --install
+
+Home-brew installed (https://brew.sh) 
+2- Copy Paste this in Terminal to install homebrew;
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+then run the following to install dependencies using Homebrew:
+Brew install wget
+Brew install openssl
+Brew install pkg-config
+Brew install zeromq
+
+Note: If cmake can not find zmq.hpp file on OS X, installing zmq.hpp from https://github.com/zeromq/cppzmq to /usr/local/include should fix that error.
+
+After everything is installed CD to the folder the build package is in and run:
+make -2
+
+The resulting executables can be found in build/release/bin
+
+- Alternatively, it can be built in an easier and more automated fashion using Homebrew when their repo is updated to include Aeon Rebase source:
+
+To install using only Homebrew:
+
+Ensure Homebrew is installed, it can be found at http://brew.sh
+
+Add the repository: brew tap sammy007/cryptonight
+
+Build wallet: brew install --HEAD aeon
+
+
+# On Windows:
+
+Dependencies: MSVC 2013 or later, CMake 2.8.6 or later, and Boost 1.53 or later.
+
+To build, change to the root of the source code directory, and run these commands:
+
+mkdir build cd build cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="c:\folder\to\boost_1_55_0" -DBOOST_LIBRARYDIR="c:\folder\to\boost_1_55_0\lib64-msvc-12.0" msbuild Project.sln /p:Configuration=Release
+
+If you don't have your path environment variable configured with the VS paths, you may may want to run 'C:\program files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat' (or equivalent) to temporarily set the environment variables.
+
+Building Documentation
+
+AEON developer documentation uses Doxygen, and is currently a work-in-progress.
+
+Dependencies: Doxygen 1.8.0 or later, Graphviz 2.28 or later (optional)
+
+To build, change to the root of the source code directory, and run 'doxygen Doxyfile'
+
+If you have installed Graphviz, you can also generate in-doc diagrams by instead running 'HAVE_DOT=YES doxygen Doxyfile'
+
+The output will be built in doc/html/
 
 [^] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must
 build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libg* /usr/lib/ ```
 
-### Cloning the repository
+------------------------------------------------------
 
-Clone recursively to pull-in needed submodule(s):
-
-`$ git clone --recursive https://github.com/monero-project/monero`
-
-If you already have a repo cloned, initialize and update:
-
-`$ cd monero && git submodule init && git submodule update`
-
-### Build instructions
-
-Monero uses the CMake build system and a top-level [Makefile](Makefile) that
-invokes cmake commands as needed.
-
-#### On Linux and OS X
-
-* Install the dependencies
-* Change to the root of the source code directory and build:
-
-        cd monero
-        make
-
-    *Optional*: If your machine has several cores and enough memory, enable
-    parallel build by running `make -j<number of threads>` instead of `make`. For
-    this to be worthwhile, the machine should have one core and about 2GB of RAM
-    available per thread.
-
-    *Note*: If cmake can not find zmq.hpp file on OS X, installing `zmq.hpp` from
-    https://github.com/zeromq/cppzmq to `/usr/local/include` should fix that error.
-
-* The resulting executables can be found in `build/release/bin`
-
-* Add `PATH="$PATH:$HOME/monero/build/release/bin"` to `.profile`
-
-* Run Monero with `monerod --detach`
-
-* **Optional**: build and run the test suite to verify the binaries:
-
-        make release-test
-
-    *NOTE*: `core_tests` test may take a few hours to complete.
-
-* **Optional**: to build binaries suitable for debugging:
-
-         make debug
-
-* **Optional**: to build statically-linked binaries:
-
-         make release-static
-
-Dependencies need to be built with -fPIC. Static libraries usually aren't, so you may have to build them yourself with -fPIC. Refer to their documentation for how to build them.
-
-* **Optional**: build documentation in `doc/html` (omit `HAVE_DOT=YES` if `graphviz` is not installed):
-
-        HAVE_DOT=YES doxygen Doxyfile
-
-#### On the Raspberry Pi
-
-Tested on a Raspberry Pi Zero with a clean install of minimal Raspbian Stretch (2017-09-07 or later) from https://www.raspberrypi.org/downloads/raspbian/. If you are using Raspian Jessie, [please see note in the following section](#note-for-raspbian-jessie-users). 
-
-* `apt-get update && apt-get upgrade` to install all of the latest software
-
-* Install the dependencies for Monero from the 'Debian' column in the table above.
-
-* Increase the system swap size:
-```	
-	sudo /etc/init.d/dphys-swapfile stop  
-	sudo nano /etc/dphys-swapfile  
-	CONF_SWAPSIZE=1024  
-	sudo /etc/init.d/dphys-swapfile start  
-```
-* Clone monero and checkout most recent release version:
-```
-        git clone https://github.com/monero-project/monero.git
-	cd monero
-	git checkout tags/v0.11.1.0
-```
-* Build:
-```
-        make release
-```
-* Wait 4-6 hours
-
-* The resulting executables can be found in `build/release/bin`
-
-* Add `PATH="$PATH:$HOME/monero/build/release/bin"` to `.profile`
-
-* Run Monero with `monerod --detach`
-
-* You may wish to reduce the size of the swap file after the build has finished, and delete the boost directory from your home directory
-
-#### *Note for Raspbian Jessie users:*
-
-If you are using the older Raspbian Jessie image, compiling Monero is a bit more complicated. The version of Boost available in the Debian Jessie repositories is too old to use with Monero, and thus you must compile a newer version yourself. The following explains the extra steps, and has been tested on a Raspberry Pi 2 with a clean install of minimal Raspbian Jessie.
-
-* As before, `apt-get update && apt-get upgrade` to install all of the latest software, and increase the system swap size
-
-```	
-	sudo /etc/init.d/dphys-swapfile stop  
-	sudo nano /etc/dphys-swapfile  
-	CONF_SWAPSIZE=1024  
-	sudo /etc/init.d/dphys-swapfile start  
-```
-
-* Then, install the dependencies for Monero except `libunwind` and `libboost-all-dev`
-
-* Install the latest version of boost (this may first require invoking `apt-get remove --purge libboost*` to remove a previous version if you're not using a clean install):
-```
-	cd  
-	wget https://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.bz2  
-	tar xvfo boost_1_64_0.tar.bz2  
-	cd boost_1_64_0  
-	./bootstrap.sh  
-	sudo ./b2  
-```
-* Wait ~8 hours
-```
-	sudo ./bjam install
-```
-* Wait ~4 hours
-
-* From here, follow the [general Raspberry Pi instructions](#on-the-raspberry-pi) from the "Clone monero and checkout most recent release version" step.
-
-#### On Windows:
-
-Binaries for Windows are built on Windows using the MinGW toolchain within
-[MSYS2 environment](http://msys2.github.io). The MSYS2 environment emulates a
-POSIX system. The toolchain runs within the environment and *cross-compiles*
-binaries that can run outside of the environment as a regular Windows
-application.
-
-**Preparing the build environment**
-
-* Download and install the [MSYS2 installer](http://msys2.github.io), either the 64-bit or the 32-bit package, depending on your system.
-* Open the MSYS shell via the `MSYS2 Shell` shortcut
-* Update packages using pacman:  
-
-        pacman -Syuu  
-
-* Exit the MSYS shell using Alt+F4  
-* Edit the properties for the `MSYS2 Shell` shortcut changing "msys2_shell.bat" to "msys2_shell.cmd -mingw64" for 64-bit builds or "msys2_shell.cmd -mingw32" for 32-bit builds
-* Restart MSYS shell via modified shortcut and update packages again using pacman:  
-
-        pacman -Syuu  
-
-
-* Install dependencies:
-
-    To build for 64-bit Windows:
-
-        pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium
-
-    To build for 32-bit Windows:
- 
-        pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost mingw-w64-i686-openssl mingw-w64-i686-zeromq mingw-w64-i686-libsodium
-
-* Open the MingW shell via `MinGW-w64-Win64 Shell` shortcut on 64-bit Windows
-  or `MinGW-w64-Win64 Shell` shortcut on 32-bit Windows. Note that if you are
-  running 64-bit Windows, you will have both 64-bit and 32-bit MinGW shells.
-
-**Building**
-
-* If you are on a 64-bit system, run:
-
-        make release-static-win64
-
-* If you are on a 32-bit system, run:
-
-        make release-static-win32
-
-* The resulting executables can be found in `build/release/bin`
-
-### On FreeBSD:
-
-The project can be built from scratch by following instructions for Linux above. If you are running monero in a jail you need to add the flag: `allow.sysvipc=1` to your jail configuration, otherwise lmdb will throw the error message: `Failed to open lmdb environment: Function not implemented`.
-
-We expect to add Monero into the ports tree in the near future, which will aid in managing installations using ports or packages.
-
-### On OpenBSD:
-
-#### OpenBSD < 6.2
-
-This has been tested on OpenBSD 5.8.
-
-You will need to add a few packages to your system. `pkg_add db cmake gcc gcc-libs g++ miniupnpc gtest`.
-
-The doxygen and graphviz packages are optional and require the xbase set.
-
-The Boost package has a bug that will prevent librpc.a from building correctly. In order to fix this, you will have to Build boost yourself from scratch. Follow the directions here (under "Building Boost"):
-https://github.com/bitcoin/bitcoin/blob/master/doc/build-openbsd.md
-
-You will have to add the serialization, date_time, and regex modules to Boost when building as they are needed by Monero.
-
-To build: `env CC=egcc CXX=eg++ CPP=ecpp DEVELOPER_LOCAL_TOOLS=1 BOOST_ROOT=/path/to/the/boost/you/built make release-static-64`
-
-#### OpenBSD >= 6.2
-
-You will need to add a few packages to your system. `pkg_add cmake miniupnpc zeromq libiconv`.
-
-The doxygen and graphviz packages are optional and require the xbase set.
-
-
-Build the Boost library using clang. This guide is derived from: https://github.com/bitcoin/bitcoin/blob/master/doc/build-openbsd.md
-
-We assume you are compiling with a non-root user and you have `doas` enabled.
-
-Note: do not use the boost package provided by OpenBSD, as we are installing boost to `/usr/local`.
-
-```
-# Create boost building directory
-mkdir ~/boost
-cd ~/boost
-
-# Fetch boost source
-ftp -o boost_1_64_0.tar.bz2 https://netcologne.dl.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2 
-
-# MUST output: (SHA256) boost_1_64_0.tar.bz2: OK
-echo "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332 boost_1_64_0.tar.bz2" | sha256 -c
-tar xfj boost_1_64_0.tar.bz2
-
-# Fetch and apply boost patches, required for OpenBSD
-ftp -o boost_test_impl_execution_monitor_ipp.patch https://raw.githubusercontent.com/openbsd/ports/bee9e6df517077a7269ff0dfd57995f5c6a10379/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp
-ftp -o boost_config_platform_bsd_hpp.patch https://raw.githubusercontent.com/openbsd/ports/90658284fb786f5a60dd9d6e8d14500c167bdaa0/devel/boost/patches/patch-boost_config_platform_bsd_hpp
-
-# MUST output: (SHA256) boost_config_platform_bsd_hpp.patch: OK
-echo "1f5e59d1154f16ee1e0cc169395f30d5e7d22a5bd9f86358f738b0ccaea5e51d boost_config_platform_bsd_hpp.patch" | sha256 -c
-# MUST output: (SHA256) boost_test_impl_execution_monitor_ipp.patch: OK
-echo "30cec182a1437d40c3e0bd9a866ab5ddc1400a56185b7e671bb3782634ed0206 boost_test_impl_execution_monitor_ipp.patch" | sha256 -c
-
-cd boost_1_64_0
-patch -p0 < ../boost_test_impl_execution_monitor_ipp.patch
-patch -p0 < ../boost_config_platform_bsd_hpp.patch
-
-# Start building boost
-echo 'using clang : : c++ : <cxxflags>"-fvisibility=hidden -fPIC" <linkflags>"" <archiver>"ar" <striper>"strip"  <ranlib>"ranlib" <rc>"" : ;' > user-config.jam
-./bootstrap.sh --without-icu --with-libraries=chrono,filesystem,program_options,system,thread,test,date_time,regex,serialization,locale --with-toolset=clang
-./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" -sICONV_PATH=/usr/local
-doas ./b2 -d0 runtime-link=shared threadapi=pthread threading=multi link=static variant=release --layout=tagged --build-type=complete --user-config=user-config.jam -sNO_BZIP2=1 -sICONV_PATH=/usr/local --prefix=/usr/local install
-```
-
-Build cppzmq
-
-Build the cppzmq bindings.
-
-We assume you are compiling with a non-root user and you have `doas` enabled.
-
-```
-# Create cppzmq building directory
-mkdir ~/cppzmq
-cd ~/cppzmq
-
-# Fetch cppzmq source
-ftp -o cppzmq-4.2.3.tar.gz https://github.com/zeromq/cppzmq/archive/v4.2.3.tar.gz
-
-# MUST output: (SHA256) cppzmq-4.2.3.tar.gz: OK
-echo "3e6b57bf49115f4ae893b1ff7848ead7267013087dc7be1ab27636a97144d373 cppzmq-4.2.3.tar.gz" | sha256 -c
-tar xfz cppzmq-4.2.3.tar.gz
-
-# Start building cppzmq
-cd cppzmq-4.2.3
-mkdir build
-cd build
-cmake ..
-doas make install
-```
-
-Build monero: `env DEVELOPER_LOCAL_TOOLS=1 BOOST_ROOT=/usr/local make release-static`
-
-### On Solaris:
-
-The default Solaris linker can't be used, you have to install GNU ld, then run cmake manually with the path to your copy of GNU ld:
-
-        mkdir -p build/release
-        cd build/release
-        cmake -DCMAKE_LINKER=/path/to/ld -D CMAKE_BUILD_TYPE=Release ../..
-        cd ../..
-
-Then you can run make as usual.
-
-### On Linux for Android (using docker):
-
-        # Build image (select android64.Dockerfile for aarch64)
-        cd utils/build_scripts/ && docker build -f android32.Dockerfile -t monero-android .
-        # Create container
-        docker create -it --name monero-android monero-android bash
-        # Get binaries
-        docker cp monero-android:/opt/android/monero/build/release/bin .
-
-### Building portable statically linked binaries
-
-By default, in either dynamically or statically linked builds, binaries target the specific host processor on which the build happens and are not portable to other processors. Portable binaries can be built using the following targets:
-
-* ```make release-static-linux-x86_64``` builds binaries on Linux on x86_64 portable across POSIX systems on x86_64 processors
-* ```make release-static-linux-i686``` builds binaries on Linux on x86_64 or i686 portable across POSIX systems on i686 processors
-* ```make release-static-linux-armv8``` builds binaries on Linux portable across POSIX systems on armv8 processors
-* ```make release-static-linux-armv7``` builds binaries on Linux portable across POSIX systems on armv7 processors
-* ```make release-static-linux-armv6``` builds binaries on Linux portable across POSIX systems on armv6 processors
-* ```make release-static-win64``` builds binaries on 64-bit Windows portable across 64-bit Windows systems
-* ```make release-static-win32``` builds binaries on 64-bit or 32-bit Windows portable across 32-bit Windows systems
-
-## Running monerod
-
-The build places the binary in `bin/` sub-directory within the build directory
-from which cmake was invoked (repository root by default). To run in
-foreground:
-
-    ./bin/monerod
-
-To list all available options, run `./bin/monerod --help`.  Options can be
-specified either on the command line or in a configuration file passed by the
-`--config-file` argument.  To specify an option in the configuration file, add
-a line with the syntax `argumentname=value`, where `argumentname` is the name
-of the argument without the leading dashes, for example `log-level=1`.
-
-To run in background:
-
-    ./bin/monerod --log-file monerod.log --detach
-
-To run as a systemd service, copy
-[monerod.service](utils/systemd/monerod.service) to `/etc/systemd/system/` and
-[monerod.conf](utils/conf/monerod.conf) to `/etc/`. The [example
-service](utils/systemd/monerod.service) assumes that the user `monero` exists
-and its home is the data directory specified in the [example
-config](utils/conf/monerod.conf).
-
-If you're on Mac, you may need to add the `--max-concurrency 1` option to
-monero-wallet-cli, and possibly monerod, if you get crashes refreshing.
-
-## Internationalization
-
-See [README.i18n.md](README.i18n.md).
-
-## Using Tor
-
-While Monero isn't made to integrate with Tor, it can be used wrapped with torsocks, by
-setting the following configuration parameters and environment variables:
-
-* `--p2p-bind-ip 127.0.0.1` on the command line or `p2p-bind-ip=127.0.0.1` in
-  monerod.conf to disable listening for connections on external interfaces.
-* `--no-igd` on the command line or `no-igd=1` in monerod.conf to disable IGD
-  (UPnP port forwarding negotiation), which is pointless with Tor.
-* `DNS_PUBLIC=tcp` or `DNS_PUBLIC=tcp://x.x.x.x` where x.x.x.x is the IP of the
-  desired DNS server, for DNS requests to go over TCP, so that they are routed
-  through Tor. When IP is not specified, monerod uses the default list of
-  servers defined in [src/common/dns_utils.cpp](src/common/dns_utils.cpp).
-* `TORSOCKS_ALLOW_INBOUND=1` to tell torsocks to allow monerod to bind to interfaces
-   to accept connections from the wallet. On some Linux systems, torsocks
-   allows binding to localhost by default, so setting this variable is only
-   necessary to allow binding to local LAN/VPN interfaces to allow wallets to
-   connect from remote hosts. On other systems, it may be needed for local wallets
-   as well.
-* Do NOT pass `--detach` when running through torsocks with systemd, (see
-  [utils/systemd/monerod.service](utils/systemd/monerod.service) for details).
-
-Example command line to start monerod through Tor:
-
-    DNS_PUBLIC=tcp torsocks monerod --p2p-bind-ip 127.0.0.1 --no-igd
-
-### Using Tor on Tails
-
-TAILS ships with a very restrictive set of firewall rules. Therefore, you need
-to add a rule to allow this connection too, in addition to telling torsocks to
-allow inbound connections. Full example:
-
-    sudo iptables -I OUTPUT 2 -p tcp -d 127.0.0.1 -m tcp --dport 18081 -j ACCEPT
-    DNS_PUBLIC=tcp torsocks ./monerod --p2p-bind-ip 127.0.0.1 --no-igd --rpc-bind-ip 127.0.0.1 \
-        --data-dir /home/amnesia/Persistent/your/directory/to/the/blockchain
-
-## Debugging
-
-This section contains general instructions for debugging failed installs or problems encountered with Monero. First ensure you are running the latest version built from the Github repo.
-
-### Obtaining stack traces and core dumps on Unix systems
-
-We generally use the tool `gdb` (GNU debugger) to provide stack trace functionality, and `ulimit` to provide core dumps in builds which crash or segfault.
-
-* To use gdb in order to obtain a stack trace for a build that has stalled:
-
-Run the build.
-
-Once it stalls, enter the following command:
-
-```
-gdb /path/to/monerod `pidof monerod` 
-```
-
-Type `thread apply all bt` within gdb in order to obtain the stack trace
-
-* If however the core dumps or segfaults:
-
-Enter `ulimit -c unlimited` on the command line to enable unlimited filesizes for core dumps
-
-Enter `echo core | sudo tee /proc/sys/kernel/core_pattern` to stop cores from being hijacked by other tools
-
-Run the build.
-
-When it terminates with an output along the lines of "Segmentation fault (core dumped)", there should be a core dump file in the same directory as monerod. It may be named just `core`, or `core.xxxx` with numbers appended.
-
-You can now analyse this core dump with `gdb` as follows:
-
-`gdb /path/to/monerod /path/to/dumpfile`
-
-Print the stack trace with `bt`
-
-* To run monero within gdb:
-
-Type `gdb /path/to/monerod`
-
-Pass command-line options with `--args` followed by the relevant arguments
-
-Type `run` to run monerod
-
-### Analysing memory corruption
-
-We use the tool `valgrind` for this.
-
-Run with `valgrind /path/to/monerod`. It will be slow.
-
-### LMDB
+# LMDB
 
 Instructions for debugging suspected blockchain corruption as per @HYC
 
 There is an `mdb_stat` command in the LMDB source that can print statistics about the database but it's not routinely built. This can be built with the following command:
 
-`cd ~/monero/external/db_drivers/liblmdb && make`
+`cd ~/Aeon/external/db_drivers/liblmdb && make`
 
 The output of `mdb_stat -ea <path to blockchain dir>` will indicate inconsistencies in the blocks, block_heights and block_info table.
 

--- a/README.md
+++ b/README.md
@@ -179,30 +179,44 @@ Build wallet: brew install --HEAD aeon
 
 # On Windows:
 
-Dependencies: MSVC 2013 or later, CMake 2.8.6 or later, and Boost 1.53 or later.
+Binaries for Windows are built on Windows using the MinGW toolchain within MSYS2 environment. The MSYS2 environment emulates a POSIX system. The toolchain runs within the environment and cross-compiles binaries that can run outside of the environment as a regular Windows application.
 
-To build, change to the root of the source code directory, and run these commands:
+Preparing the build environment
 
-mkdir build cd build cmake -G "Visual Studio 12 Win64" -DBOOST_ROOT="c:\folder\to\boost_1_55_0" -DBOOST_LIBRARYDIR="c:\folder\to\boost_1_55_0\lib64-msvc-12.0" msbuild Project.sln /p:Configuration=Release
+Download and install the MSYS2 installer, either the 64-bit or the 32-bit package, depending on your system.
 
-If you don't have your path environment variable configured with the VS paths, you may may want to run 'C:\program files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat' (or equivalent) to temporarily set the environment variables.
+Open the MSYS shell via the MSYS2 Shell shortcut
 
-Please note that if using a newer version of MSVC please subsitute -G "Visual Studio 12 Win64" and subsequent file paths with correct version for proper compiling.
+Update packages using pacman:
 
-Building Documentation
+  pacman -Syuu  
+Exit the MSYS shell using Alt+F4
 
-AEON developer documentation uses Doxygen, and is currently a work-in-progress.
+Edit the properties for the MSYS2 Shell shortcut changing "msys2_shell.bat" to "msys2_shell.cmd -mingw64" for 64-bit builds or "msys2_shell.cmd -mingw32" for 32-bit builds
 
-Dependencies: Doxygen 1.8.0 or later, Graphviz 2.28 or later (optional)
+Restart MSYS shell via modified shortcut and update packages again using pacman:
 
-To build, change to the root of the source code directory, and run 'doxygen Doxyfile'
+  pacman -Syuu  
+Install dependencies:
 
-If you have installed Graphviz, you can also generate in-doc diagrams by instead running 'HAVE_DOT=YES doxygen Doxyfile'
+To build for 64-bit Windows:
 
-The output will be built in doc/html/
+  pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium
+To build for 32-bit Windows:
 
-[^] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must
-build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libg* /usr/lib/ ```
+  pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost mingw-w64-i686-openssl mingw-w64-i686-zeromq mingw-w64-i686-libsodium
+Open the MingW shell via MinGW-w64-Win64 Shell shortcut on 64-bit Windows or MinGW-w64-Win64 Shell shortcut on 32-bit Windows. Note that if you are running 64-bit Windows, you will have both 64-bit and 32-bit MinGW shells.
+
+Building
+
+If you are on a 64-bit system, run:
+
+  make release-static-win64
+If you are on a 32-bit system, run:
+
+  make release-static-win32
+
+The resulting executables can be found in build/release/bin
 
 
 # LMDB

--- a/README.md
+++ b/README.md
@@ -128,50 +128,79 @@ Cloning the repository
 
 Clone recursively to pull-in needed submodule(s):
 
+```
 $ git clone --recursive https://github.com/aeonix/aeon
+```
 
 If you already have a repo cloned, initialize and update:
 
-$ cd monero && git submodule init && git submodule update
+```
+$ cd aeon && git submodule init && git submodule update
+```
 
 Build instructions
 
 Aeon uses the CMake build system and a top-level Makefile that invokes cmake commands as needed.
 
-On Linux and OS X
+- On Linux and OS X
 
 Install the dependencies
 
 Change to the root of the source code directory and build:
 
+  ```
   cd aeon
+  ```
+  
+  ```
   make
+  ```
+  
 Optional: If your machine has several cores and enough memory, enable parallel build by running make -j<number of threads> instead of make. For this to be worthwhile, the machine should have one core and about 2GB of RAM available per thread.
-
+  
+  ```
+  cd aeon
+  ```
+  
+  ```
+  make -j 2
+  ```
+  
 Note: If cmake can not find zmq.hpp file on OS X, installing zmq.hpp from https://github.com/zeromq/cppzmq to /usr/local/include should fix that error.
 
 The resulting executables can be found in build/release/bin
 
+```
 Add PATH="$PATH:$HOME/aeon/build/release/bin" to .profile
-
-Run Monero with aeond --detach
+```
 
 Optional: build and run the test suite to verify the binaries:
 
+  ```
   make release-test
+  ```
+  
 NOTE: core_tests test may take a few hours to complete.
 
 Optional: to build binaries suitable for debugging:
 
+   ```
    make debug
+   ```
+   
 Optional: to build statically-linked binaries:
 
+   ```
    make release-static
+   ```
+   
 Dependencies need to be built with -fPIC. Static libraries usually aren't, so you may have to build them yourself with -fPIC. Refer to their documentation for how to build them.
 
 Optional: build documentation in doc/html (omit HAVE_DOT=YES if graphviz is not installed):
 
+  ```
   HAVE_DOT=YES doxygen Doxyfile
+  ```
   
 # On OS X:
 
@@ -185,15 +214,20 @@ Home-brew installed (https://brew.sh)
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 then run the following to install dependencies using Homebrew:
+```
 Brew install wget
 Brew install openssl
 Brew install pkg-config
 Brew install zeromq
+```
 
 Note: If cmake can not find zmq.hpp file on OS X, installing zmq.hpp from https://github.com/zeromq/cppzmq to /usr/local/include should fix that error.
 
 After everything is installed CD to the folder the build package is in and run:
-make -2
+
+```
+make -j 2
+```
 
 The resulting executables can be found in build/release/bin
 
@@ -205,7 +239,11 @@ Ensure Homebrew is installed, it can be found at http://brew.sh
 
 Add the repository: brew tap sammy007/cryptonight
 
-Build wallet: brew install --HEAD aeon
+Build wallet: 
+
+```
+brew install --HEAD aeon
+```
 
 
 # On Windows:
@@ -257,11 +295,17 @@ https://github.com/aeonix/aeon/tree/v0.12.0.0#dependencies
 
 Run these commands:
 
+```
 git clone --recursive https://github.com/aeonix/aeon.git aeon_sophia 
+```
 
+```
 cd aeon_sophia
+```
 
+```
 make release
+```
 
 
 # LMDB


### PR DESCRIPTION
Made changes to the rebase version of README.MD to apply to AEON. File was originally written from MONERO git readme file and did not apply to Aeon. 
Also added in appropriate compile instructions for OSX due to sammy007 not having Home-brew updated to aeon-rebase code. Instructions are still added for compiling with brew with comment for non functionality until BREW repo is updated. 