### PR TITLE
Set mainnet v7 fork height to 963500 (June 3rd 2018) with diff reset to 2 billion

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -92,8 +92,12 @@ static const struct {
 } mainnet_hard_forks[] = {
   // version 1 from the start of the blockchain
   { 1, 1, 0, 1341378000, 0 },
+
+  // versions 2, 3, 4, 5 and 6 are skipped, in favor of reducing the cost of adopting the POW change and other consensus updates from Monero
+  // version 7 starts from block 963500, which is on or around the 3rd of June, 2018. Fork time finalised on 2018-05-24.
+  { 7, 963500, 0, 1527137212, 2000000000 },
 };
-static const uint64_t mainnet_hard_fork_version_1_till = 0;
+static const uint64_t mainnet_hard_fork_version_1_till = 963499;
 
 static const struct {
   uint8_t version;


### PR DESCRIPTION
***The rationale behind the reset diff value***

Let us define a coin's "profitability" as:

    (price_per_coin * block_reward) / (cost_per_hash * difficulty)

which should be ideally constant regardless of coins and PoW algorithms. Let us also denote CryptoNight's cost per hash as `C`, and let us further assume that CryptoNight-Lite's cost per hash is `0.25 * C` (due to halved scratchpad size and halved iteration counts).

The current state of Monero and Aeon are:

Monero (at height 1579539):
- Price: 175.85 USD/XMR
- Block reward: 4.548983 XMR
- Difficulty: 52111790961

Aeon (at height 959771):
- Price: 1.54 USD/AEON
- Block reward: 9.854010 AEON
- Difficulty: 30350051855

The reset difficulty value `X` for Aeon at the fork should therefore satisfy:

    (175.85 * 4.548983) / (C * 52111790961) == (1.54 * 9.854010) / (0.25 * C * X)

in order to make Aeon's profitability 'reasonable' after the difficulty reset.
Therefore,

    X = (1.54 * 9.854010) * 52111790961 / (0.25 * 175.85 * 4.548983)
      ~= 3.9 billion

Directly using this value could still cause a bit of stall due to price volatility and other uncertainties, and underestimating the 'right' difficulty is generally less harmful than overestimating it (i.e. the blockchain growth will be a bit faster for a few tens of blocks). Therefore, the reset value is set to roughly half of the above `X`.
