### PR TITLE
Update help language file

### DIFF
--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -3716,7 +3716,7 @@ daemon to work correctly.</source>
     </message>
     <message>
         <location filename="../src/wallet/wallet2.cpp" line="117"/>
-        <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
+        <source>Use daemon instance at port &lt;arg&gt; instead of 11181.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Change from Monero RPC port to AEON RPC port + remove port option on --daemon-address.

I believe that stating 'on default RPC port' will push others to use --daemon-port for custom ports. If no port specified, default RPC port is used anyways.