### PR TITLE
util: remove unused <ustat.h> /monero#4274

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -37,7 +37,6 @@
 #ifdef __GLIBC__
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <ustat.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <string.h>


### PR DESCRIPTION
It's obsolete and removed from at least Arch Linux 8.2

Reported by moneroexamples