### PR TITLE
Fix cryptonote_tx_utils.cpp build /monero#4476

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -127,7 +127,7 @@ namespace cryptonote
         out_amounts[1] += out_amounts[0];
         for (size_t n = 1; n < out_amounts.size(); ++n)
           out_amounts[n - 1] = out_amounts[n];
-        out_amounts.resize(out_amounts.size() - 1);
+        out_amounts.pop_back();
       }
     }
     else


### PR DESCRIPTION
Fix cryptonote_tx_utils.cpp build:
Building CXX object src/cryptonote_core/CMakeFiles/obj_cryptonote_core.dir/cryptonote_tx_utils.cpp.o
In function ‘bool cryptonote::construct_miner_tx(size_t, size_t, uint64_t, size_t, uint64_t, const cryptonote::account_public_address&, cryptonote::transaction&, const blobdata&, size_t, uint8_t)’:
cc1plus: error: ‘void* __builtin_memset(void*, int, long unsigned int)’: specified size 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
cc1plus: all warnings being treated as errors
src/cryptonote_core/CMakeFiles/obj_cryptonote_core.dir/build.make:134: recipe for target 'src/cryptonote_core/CMakeFiles/obj_cryptonote_core.dir/cryptonote_tx_utils.cpp.o' failed
make[2]: *** [src/cryptonote_core/CMakeFiles/obj_cryptonote_core.dir/cryptonote_tx_utils.cpp.o] Error 1
CMakeFiles/Makefile2:1312: recipe for target 'src/cryptonote_core/CMakeFiles/obj_cryptonote_core.dir/all' failed
make[1]: *** [src/cryptonote_core/CMakeFiles/obj_cryptonote_core.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2