### PR TITLE
Changed Windows build commands. /monero#5043

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,13 +288,13 @@ application.
 * Open the MSYS shell via the `MSYS2 Shell` shortcut
 * Update packages using pacman:  
 
-        pacman -Syuu  
+        pacman -Syu  
 
 * Exit the MSYS shell using Alt+F4  
 * Edit the properties for the `MSYS2 Shell` shortcut changing "msys2_shell.bat" to "msys2_shell.cmd -mingw64" for 64-bit builds or "msys2_shell.cmd -mingw32" for 32-bit builds
 * Restart MSYS shell via modified shortcut and update packages again using pacman:  
 
-        pacman -Syuu  
+        pacman -Syu  
 
 
 * Install dependencies:


### PR DESCRIPTION
`pacman -Syuu` can either upgrade or degrade the packages (depending upon the package lists), and should not be normally used. Instead of that, one should use `pacman -Syu` which only upgrades the packages.