### PR TITLE
Better error when sending a tx with a too large extra field /monero#5182

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8031,6 +8031,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       {
         const size_t estimated_rct_tx_size = estimate_tx_size(use_rct, tx.selected_transfers.size(), fake_outs_count, tx.dsts.size(), extra.size(), bulletproof);
         try_tx = dsts.empty() || (estimated_rct_tx_size >= TX_SIZE_TARGET(upper_transaction_size_limit));
+        THROW_WALLET_EXCEPTION_IF(try_tx && tx.dsts.empty(), error::tx_too_big, estimated_rct_tx_size, upper_transaction_size_limit);
       }
     }
 

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -673,26 +673,43 @@ namespace tools
       explicit tx_too_big(std::string&& loc, const cryptonote::transaction& tx, uint64_t tx_size_limit)
         : transfer_error(std::move(loc), "transaction is too big")
         , m_tx(tx)
+        , m_tx_valid(true)
+        , m_tx_size(cryptonote::get_object_blobsize(tx))
         , m_tx_size_limit(tx_size_limit)
       {
       }
 
+      explicit tx_too_big(std::string&& loc, uint64_t tx_size, uint64_t tx_size_limit)
+        : transfer_error(std::move(loc), "transaction would be too big")
+        , m_tx_valid(false)
+        , m_tx_size(tx_size)
+        , m_tx_size_limit(tx_size_limit)
+      {
+      }
+
+      bool tx_valid() const { return m_tx_valid; }
       const cryptonote::transaction& tx() const { return m_tx; }
+      uint64_t tx_size() const { return m_tx_size; }
       uint64_t tx_size_limit() const { return m_tx_size_limit; }
 
       std::string to_string() const
       {
         std::ostringstream ss;
-        cryptonote::transaction tx = m_tx;
         ss << transfer_error::to_string() <<
           ", tx_size_limit = " << m_tx_size_limit <<
-          ", tx size = " << get_object_blobsize(m_tx) <<
-          ", tx:\n" << cryptonote::obj_to_json_str(tx);
+          ", tx size = " << m_tx_size;
+        if (m_tx_valid)
+        {
+          cryptonote::transaction tx = m_tx;
+          ss << ", tx:\n" << cryptonote::obj_to_json_str(tx);
+        }
         return ss.str();
       }
 
     private:
       cryptonote::transaction m_tx;
+      bool m_tx_valid;
+      uint64_t m_tx_size;
       uint64_t m_tx_size_limit;
     };
     //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
where a tx with even a single output cannot be created due to size limit