### PR TITLE
Upstream merge 4

### DIFF
--- a/contrib/epee/include/fnv1.h
+++ b/contrib/epee/include/fnv1.h
@@ -1,21 +1,21 @@
-// Copyright (c) 2017-2018, The Monero Project
-//
+// Copyright (c) 2018, The Monero Project
+// 
 // All rights reserved.
-//
+// 
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-//
+// 
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -28,43 +28,18 @@
 
 #pragma once
 
-#include <array>
-#include <cstdint>
-#include <iosfwd>
-#include <string>
-
-#include "wipeable_string.h"
-#include "span.h"
-
 namespace epee
 {
-  struct to_hex
+
+namespace fnv
+{
+  inline uint64_t FNV1a(const char *ptr, size_t sz)
   {
-    //! \return A std::string containing hex of `src`.
-    static std::string string(const span<const std::uint8_t> src);
-    //! \return A epee::wipeable_string containing hex of `src`.
-    static epee::wipeable_string wipeable_string(const span<const std::uint8_t> src);
+    uint64_t h = 0xcbf29ce484222325;
+    for (size_t i = 0; i < sz; ++i)
+      h = (h ^ *(const uint8_t*)ptr++) * 0x100000001b3;
+    return h;
+  }
+}
 
-    //! \return An array containing hex of `src`.
-    template<std::size_t N>
-    static std::array<char, N * 2> array(const std::array<std::uint8_t, N>& src) noexcept
-    {
-      std::array<char, N * 2> out{{}};
-      static_assert(N <= 128, "keep the stack size down");
-      buffer_unchecked(out.data(), {src.data(), src.size()});
-      return out;
-    }
-
-    //! Append `src` as hex to `out`.
-    static void buffer(std::ostream& out, const span<const std::uint8_t> src);
-
-    //! Append `< + src + >` as hex to `out`.
-    static void formatted(std::ostream& out, const span<const std::uint8_t> src);
-
-  private:
-    template<typename T> T static convert(const span<const std::uint8_t> src);
-
-    //! Write `src` bytes as hex to `out`. `out` must be twice the length
-    static void buffer_unchecked(char* out, const span<const std::uint8_t> src) noexcept;
-  };
 }

--- a/contrib/epee/include/mlocker.h
+++ b/contrib/epee/include/mlocker.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once 
+
+#include <map>
+#include <boost/thread/mutex.hpp>
+
+namespace epee
+{
+  class mlocker
+  {
+  public:
+    mlocker(void *ptr, size_t len);
+    ~mlocker();
+
+    static size_t get_page_size();
+    static size_t get_num_locked_pages();
+    static size_t get_num_locked_objects();
+
+    static void lock(void *ptr, size_t len);
+    static void unlock(void *ptr, size_t len);
+
+  private:
+    static size_t page_size;
+    static size_t num_locked_objects;
+
+    static boost::mutex &mutex();
+    static std::map<size_t, unsigned int> &map();
+    static void lock_page(size_t page);
+    static void unlock_page(size_t page);
+
+    void *ptr;
+    size_t len;
+  };
+
+  /// Locks memory while in scope
+  ///
+  /// Primarily useful for making sure that private keys don't get swapped out
+  //  to disk
+  template <class T>
+  struct mlocked : public T {
+    using type = T;
+
+    mlocked(): T() { mlocker::lock(this, sizeof(T)); }
+    mlocked(const T &t): T(t) { mlocker::lock(this, sizeof(T)); }
+    mlocked(const mlocked<T> &mt): T(mt) { mlocker::lock(this, sizeof(T)); }
+    mlocked(const T &&t): T(t) { mlocker::lock(this, sizeof(T)); }
+    mlocked(const mlocked<T> &&mt): T(mt) { mlocker::lock(this, sizeof(T)); }
+    mlocked<T> &operator=(const mlocked<T> &mt) { T::operator=(mt); return *this; }
+    ~mlocked() { mlocker::unlock(this, sizeof(T)); }
+  };
+
+  template<typename T>
+  T& unwrap(mlocked<T>& src) { return src; }
+
+  template<typename T>
+  const T& unwrap(mlocked<T> const& src) { return src; }
+
+  template <class T, size_t N>
+  using mlocked_arr = mlocked<std::array<T, N>>;
+}

--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -328,8 +328,10 @@ namespace net_utils
 	inline bool analize_http_method(const boost::smatch& result, http::http_method& method, int& http_ver_major, int& http_ver_minor)
 	{
 		CHECK_AND_ASSERT_MES(result[0].matched, false, "simple_http_connection_handler::analize_http_method() assert failed...");
-		http_ver_major = boost::lexical_cast<int>(result[11]);
-		http_ver_minor = boost::lexical_cast<int>(result[12]);
+		if (!boost::conversion::try_lexical_convert<int>(result[11], http_ver_major))
+			return false;
+		if (!boost::conversion::try_lexical_convert<int>(result[12], http_ver_minor))
+			return false;
 
 		if(result[3].matched)
 			method = http::http_method_options;
@@ -357,7 +359,12 @@ namespace net_utils
 		boost::smatch result;	
 		if(boost::regex_search(m_cache, result, rexp_match_command_line, boost::match_default) && result[0].matched)
 		{
-			analize_http_method(result, m_query_info.m_http_method, m_query_info.m_http_ver_hi, m_query_info.m_http_ver_hi);
+			if (!analize_http_method(result, m_query_info.m_http_method, m_query_info.m_http_ver_hi, m_query_info.m_http_ver_hi))
+			{
+				m_state = http_state_error;
+				MERROR("Failed to analyze method");
+				return false;
+			}
 			m_query_info.m_URI = result[10];
 			if (!parse_uri(m_query_info.m_URI, m_query_info.m_uri_content))
 			{
@@ -554,7 +561,8 @@ namespace net_utils
 		if(!(boost::regex_search( str, result, rexp_mach_field, boost::match_default) && result[0].matched))
 			return false;
 
-		len = boost::lexical_cast<size_t>(result[0]);
+		try { len = boost::lexical_cast<size_t>(result[0]); }
+		catch(...) { return false; }
 		return true;
 	}
 	//-----------------------------------------------------------------------------------

--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -353,7 +353,7 @@ namespace net_utils
   template<class t_connection_context>
 	bool simple_http_connection_handler<t_connection_context>::handle_invoke_query_line()
 	{ 
-		STATIC_REGEXP_EXPR_1(rexp_match_command_line, "^(((OPTIONS)|(GET)|(HEAD)|(POST)|(PUT)|(DELETE)|(TRACE)) (\\S+) HTTP/(\\d+).(\\d+))\r?\n", boost::regex::icase | boost::regex::normal);
+		STATIC_REGEXP_EXPR_1(rexp_match_command_line, "^(((OPTIONS)|(GET)|(HEAD)|(POST)|(PUT)|(DELETE)|(TRACE)) (\\S+) HTTP/(\\d+)\\.(\\d+))\r?\n", boost::regex::icase | boost::regex::normal);
 		//											    123         4     5      6      7     8        9        10          11     12    
 		//size_t match_len = 0;
 		boost::smatch result;	

--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -122,6 +122,7 @@
     if(!ps.load_from_json(query_info.m_body)) \
     { \
        boost::value_initialized<epee::json_rpc::error_response> rsp; \
+       static_cast<epee::json_rpc::error_response&>(rsp).jsonrpc = "2.0"; \
        static_cast<epee::json_rpc::error_response&>(rsp).error.code = -32700; \
        static_cast<epee::json_rpc::error_response&>(rsp).error.message = "Parse error"; \
        epee::serialization::store_t_to_json(static_cast<epee::json_rpc::error_response&>(rsp), response_info.m_body); \

--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -85,6 +85,14 @@ public: \
   static_assert(std::is_pod<decltype(this_ref.varialble)>::value, "t_type must be a POD type."); \
   KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, val_name)
 
+#define KV_SERIALIZE_VAL_POD_AS_BLOB_OPT_N(varialble, val_name, default_value) \
+  do { \
+    static_assert(std::is_pod<decltype(this_ref.varialble)>::value, "t_type must be a POD type."); \
+    bool ret = KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, val_name); \
+    if (!ret) \
+      epee::serialize_default(this_ref.varialble, default_value); \
+  } while(0);
+
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, val_name) \
   epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(this_ref.varialble, stg, hparent_section, val_name);
 
@@ -92,6 +100,7 @@ public: \
 
 #define KV_SERIALIZE(varialble)                           KV_SERIALIZE_N(varialble, #varialble)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB(varialble)           KV_SERIALIZE_VAL_POD_AS_BLOB_N(varialble, #varialble)
+#define KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(varialble, def)  KV_SERIALIZE_VAL_POD_AS_BLOB_OPT_N(varialble, #varialble, def)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(varialble)     KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, #varialble) //skip is_pod compile time check
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value)

--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -46,6 +46,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include "hex.h"
 #include "memwipe.h"
+#include "mlocker.h"
 #include "span.h"
 #include "warnings.h"
 
@@ -354,6 +355,12 @@ POP_WARNINGS
   //----------------------------------------------------------------------------
   template<class t_pod_type>
   bool hex_to_pod(const std::string& hex_str, tools::scrubbed<t_pod_type>& s)
+  {
+    return hex_to_pod(hex_str, unwrap(s));
+  }
+  //----------------------------------------------------------------------------
+  template<class t_pod_type>
+  bool hex_to_pod(const std::string& hex_str, epee::mlocked<t_pod_type>& s)
   {
     return hex_to_pod(hex_str, unwrap(s));
   }

--- a/contrib/epee/include/wipeable_string.h
+++ b/contrib/epee/include/wipeable_string.h
@@ -28,28 +28,43 @@
 
 #pragma once
 
+#include <boost/optional/optional_fwd.hpp>
 #include <stddef.h>
 #include <vector>
 #include <string>
+#include "fnv1.h"
 
 namespace epee
 {
   class wipeable_string
   {
   public:
+    typedef char value_type;
+
     wipeable_string() {}
     wipeable_string(const wipeable_string &other);
     wipeable_string(wipeable_string &&other);
     wipeable_string(const std::string &other);
     wipeable_string(std::string &&other);
     wipeable_string(const char *s);
+    wipeable_string(const char *s, size_t len);
     ~wipeable_string();
     void wipe();
     void push_back(char c);
-    void pop_back();
+    void operator+=(char c);
+    void operator+=(const std::string &s);
+    void operator+=(const epee::wipeable_string &s);
+    void operator+=(const char *s);
+    void append(const char *ptr, size_t len);
+    char pop_back();
     const char *data() const noexcept { return buffer.data(); }
+    char *data() noexcept { return buffer.data(); }
     size_t size() const noexcept { return buffer.size(); }
+    size_t length() const noexcept { return buffer.size(); }
     bool empty() const noexcept { return buffer.empty(); }
+    void trim();
+    void split(std::vector<wipeable_string> &fields) const;
+    boost::optional<wipeable_string> parse_hexstr() const;
     void resize(size_t sz);
     void reserve(size_t sz);
     void clear();
@@ -63,5 +78,16 @@ namespace epee
 
   private:
     std::vector<char> buffer;
+  };
+}
+
+namespace std
+{
+  template<> struct hash<epee::wipeable_string>
+  {
+    size_t operator()(const epee::wipeable_string &s) const
+    {
+      return epee::fnv::FNV1a(s.data(), s.size());
+    }
   };
 }

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -27,7 +27,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 add_library(epee STATIC hex.cpp http_auth.cpp mlog.cpp net_utils_base.cpp string_tools.cpp wipeable_string.cpp memwipe.c
-    connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp)
+    connection_basic.cpp network_throttle.cpp network_throttle-detail.cpp mlocker.cpp)
 if (USE_READLINE AND GNU_READLINE_FOUND)
   add_library(epee_readline STATIC readline_buffer.cpp)
 endif()

--- a/contrib/epee/src/hex.cpp
+++ b/contrib/epee/src/hex.cpp
@@ -52,16 +52,20 @@ namespace epee
     }
   }
 
-  std::string to_hex::string(const span<const std::uint8_t> src)
+  template<typename T>
+  T to_hex::convert(const span<const std::uint8_t> src)
   {
     if (std::numeric_limits<std::size_t>::max() / 2 < src.size())
       throw std::range_error("hex_view::to_string exceeded maximum size");
 
-    std::string out{};
+    T out{};
     out.resize(src.size() * 2);
-    buffer_unchecked(std::addressof(out[0]), src);
+    to_hex::buffer_unchecked((char*)out.data(), src); // can't see the non const version in wipeable_string??
     return out;
   }
+
+  std::string to_hex::string(const span<const std::uint8_t> src) { return convert<std::string>(src); }
+  epee::wipeable_string to_hex::wipeable_string(const span<const std::uint8_t> src) { return convert<epee::wipeable_string>(src); }
 
   void to_hex::buffer(std::ostream& out, const span<const std::uint8_t> src)
   {

--- a/contrib/epee/src/mlocker.cpp
+++ b/contrib/epee/src/mlocker.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if defined __GNUC__ && !defined _WIN32
+#define HAVE_MLOCK 1
+#endif
+
+#include <unistd.h>
+#if defined HAVE_MLOCK
+#include <sys/mman.h>
+#endif
+#include "misc_log_ex.h"
+#include "syncobj.h"
+#include "mlocker.h"
+
+static size_t query_page_size()
+{
+#if defined HAVE_MLOCK
+  long ret = sysconf(_SC_PAGESIZE);
+  if (ret <= 0)
+  {
+    MERROR("Failed to determine page size");
+    return 0;
+  }
+  MINFO("Page size: " << ret);
+  return ret;
+#else
+#warning Missing query_page_size implementation
+#endif
+  return 0;
+}
+
+static void do_lock(void *ptr, size_t len)
+{
+#if defined HAVE_MLOCK
+  int ret = mlock(ptr, len);
+  if (ret < 0)
+    MERROR("Error locking page at " << ptr << ": " << strerror(errno));
+#else
+#warning Missing do_lock implementation
+#endif
+}
+
+static void do_unlock(void *ptr, size_t len)
+{
+#if defined HAVE_MLOCK
+  int ret = munlock(ptr, len);
+  if (ret < 0)
+    MERROR("Error unlocking page at " << ptr << ": " << strerror(errno));
+#else
+#warning Missing implementation of page size detection
+#endif
+}
+
+namespace epee
+{
+  size_t mlocker::page_size = 0;
+  size_t mlocker::num_locked_objects = 0;
+
+  boost::mutex &mlocker::mutex()
+  {
+    static boost::mutex vmutex;
+    return vmutex;
+  }
+  std::map<size_t, unsigned int> &mlocker::map()
+  {
+    static std::map<size_t, unsigned int> vmap;
+    return vmap;
+  }
+
+  size_t mlocker::get_page_size()
+  {
+    CRITICAL_REGION_LOCAL(mutex());
+    if (page_size == 0)
+      page_size = query_page_size();
+    return page_size;
+  }
+
+  mlocker::mlocker(void *ptr, size_t len): ptr(ptr), len(len)
+  {
+    lock(ptr, len);
+  }
+
+  mlocker::~mlocker()
+  {
+    unlock(ptr, len);
+  }
+
+  void mlocker::lock(void *ptr, size_t len)
+  {
+    size_t page_size = get_page_size();
+    if (page_size == 0)
+      return;
+
+    CRITICAL_REGION_LOCAL(mutex());
+    const size_t first = ((uintptr_t)ptr) / page_size;
+    const size_t last = (((uintptr_t)ptr) + len - 1) / page_size;
+    for (size_t page = first; page <= last; ++page)
+      lock_page(page);
+    ++num_locked_objects;
+  }
+
+  void mlocker::unlock(void *ptr, size_t len)
+  {
+    size_t page_size = get_page_size();
+    if (page_size == 0)
+      return;
+    CRITICAL_REGION_LOCAL(mutex());
+    const size_t first = ((uintptr_t)ptr) / page_size;
+    const size_t last = (((uintptr_t)ptr) + len - 1) / page_size;
+    for (size_t page = first; page <= last; ++page)
+      unlock_page(page);
+    --num_locked_objects;
+  }
+
+  size_t mlocker::get_num_locked_pages()
+  {
+    CRITICAL_REGION_LOCAL(mutex());
+    return map().size();
+  }
+
+  size_t mlocker::get_num_locked_objects()
+  {
+    CRITICAL_REGION_LOCAL(mutex());
+    return num_locked_objects;
+  }
+
+  void mlocker::lock_page(size_t page)
+  {
+    std::pair<std::map<size_t, unsigned int>::iterator, bool> p = map().insert(std::make_pair(page, 1));
+    if (p.second)
+    {
+      do_lock((void*)(page * page_size), page_size);
+    }
+    else
+    {
+      ++p.first->second;
+    }
+  }
+
+  void mlocker::unlock_page(size_t page)
+  {
+    std::map<size_t, unsigned int>::iterator i = map().find(page);
+    if (i == map().end())
+    {
+      MERROR("Attempt to unlock unlocked page at " << (void*)(page * page_size));
+    }
+    else
+    {
+      if (!--i->second)
+      {
+        map().erase(i);
+        do_unlock((void*)(page * page_size), page_size);
+      }
+    }
+  }
+}

--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -142,7 +142,9 @@ void mlog_configure(const std::string &filename_base, bool console, const std::s
     {
       std::vector<boost::filesystem::path> found_files;
       const boost::filesystem::directory_iterator end_itr;
-      for (boost::filesystem::directory_iterator iter(boost::filesystem::path(filename_base).parent_path()); iter != end_itr; ++iter)
+      const boost::filesystem::path filename_base_path(filename_base);
+      const boost::filesystem::path parent_path = filename_base_path.has_parent_path() ? filename_base_path.parent_path() : ".";
+      for (boost::filesystem::directory_iterator iter(parent_path); iter != end_itr; ++iter)
       {
         const std::string filename = iter->path().string();
         if (filename.size() >= filename_base.size() && std::memcmp(filename.data(), filename_base.data(), filename_base.size()) == 0)

--- a/contrib/snap/monerod.conf
+++ b/contrib/snap/monerod.conf
@@ -1,8 +1,9 @@
 # Configuration for monerod
 # Syntax: any command line option may be specified as 'clioptionname=value'.
+#         Boolean options such as 'no-igd' are specified as 'no-igd=1'.
 # See 'monerod --help' for all available options.
 
-# Overrided by snap:
+# Overridden by snap:
 # data-dir=/var/lib/monero
 # log-file=/var/log/monero/monero.log
 

--- a/external/easylogging++/easylogging++.cc
+++ b/external/easylogging++/easylogging++.cc
@@ -2092,6 +2092,17 @@ void VRegistry::setFromArgs(const base::utils::CommandLineArgs* commandLineArgs)
 #   define ELPP_DEFAULT_LOGGING_FLAGS 0x0
 #endif // !defined(ELPP_DEFAULT_LOGGING_FLAGS)
 // Storage
+el::base::type::StoragePointer getresetELPP(bool reset)
+{
+  static el::base::type::StoragePointer p(new el::base::Storage(el::LogBuilderPtr(new el::base::DefaultLogBuilder())));
+  if (reset)
+    p = NULL;
+  return p;
+}
+el::base::type::StoragePointer el::base::Storage::getELPP()
+{
+  return getresetELPP(false);
+}
 #if ELPP_ASYNC_LOGGING
 Storage::Storage(const LogBuilderPtr& defaultLogBuilder, base::IWorker* asyncDispatchWorker) :
 #else
@@ -2140,6 +2151,7 @@ Storage::Storage(const LogBuilderPtr& defaultLogBuilder) :
 
 Storage::~Storage(void) {
   ELPP_INTERNAL_INFO(4, "Destroying storage");
+  getresetELPP(true);
 #if ELPP_ASYNC_LOGGING
   ELPP_INTERNAL_INFO(5, "Replacing log dispatch callback to synchronous");
   uninstallLogDispatchCallback<base::AsyncLogDispatchCallback>(std::string("AsyncLogDispatchCallback"));

--- a/external/easylogging++/easylogging++.h
+++ b/external/easylogging++/easylogging++.h
@@ -2771,6 +2771,8 @@ class Storage : base::NoCopy, public base::threading::ThreadSafe {
     return it->second;
   }
 
+  static el::base::type::StoragePointer getELPP();
+
  private:
   base::RegisteredHitCounters* m_registeredHitCounters;
   base::RegisteredLoggers* m_registeredLoggers;
@@ -2803,7 +2805,7 @@ class Storage : base::NoCopy, public base::threading::ThreadSafe {
   }
 };
 extern ELPP_EXPORT base::type::StoragePointer elStorage;
-#define ELPP el::base::elStorage
+#define ELPP el::base::Storage::getELPP()
 class DefaultLogDispatchCallback : public LogDispatchCallback {
  protected:
   void handle(const LogDispatchData* data);
@@ -4633,10 +4635,9 @@ el::base::debug::CrashHandler elCrashHandler(ELPP_USE_DEF_CRASH_HANDLER); \
 }
 
 #if ELPP_ASYNC_LOGGING
-#  define INITIALIZE_EASYLOGGINGPP ELPP_INIT_EASYLOGGINGPP(new el::base::Storage(el::LogBuilderPtr(new el::base::DefaultLogBuilder()),\
-new el::base::AsyncDispatchWorker()))
+#  define INITIALIZE_EASYLOGGINGPP ELPP_INIT_EASYLOGGINGPP(NULL)
 #else
-#  define INITIALIZE_EASYLOGGINGPP ELPP_INIT_EASYLOGGINGPP(new el::base::Storage(el::LogBuilderPtr(new el::base::DefaultLogBuilder())))
+#  define INITIALIZE_EASYLOGGINGPP ELPP_INIT_EASYLOGGINGPP(NULL)
 #endif  // ELPP_ASYNC_LOGGING
 #define INITIALIZE_NULL_EASYLOGGINGPP \
 namespace el {\

--- a/src/blockchain_db/berkeleydb/db_bdb.h
+++ b/src/blockchain_db/berkeleydb/db_bdb.h
@@ -303,7 +303,6 @@ public:
   virtual uint64_t get_indexing_base() const { return 1; }
 
   virtual output_data_t get_output_key(const uint64_t& amount, const uint64_t& index);
-  virtual output_data_t get_output_key(const uint64_t& global_index) const;
   virtual void get_output_key(const uint64_t &amount, const std::vector<uint64_t> &offsets, std::vector<output_data_t> &outputs);
 
   virtual tx_out_index get_output_tx_and_index_from_global(const uint64_t& index) const;
@@ -419,6 +418,7 @@ private:
    * @return the global index of the desired output
    */
   uint64_t get_output_global_index(const uint64_t& amount, const uint64_t& index);
+  output_data_t get_output_key(const uint64_t& global_index) const;
   void checkpoint_worker() const;
   void check_open() const;
 

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -87,8 +87,8 @@ const command_line::arg_descriptor<std::string> arg_db_type = {
 };
 const command_line::arg_descriptor<std::string> arg_db_sync_mode = {
   "db-sync-mode"
-, "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[nblocks_per_sync]." 
-, "fast:async:1000"
+, "Specify sync option, using format [safe|fast|fastest]:[sync|async]:[<nblocks_per_sync>[blocks]|<nbytes_per_sync>[bytes]]." 
+, "fast:async:250000000bytes"
 };
 const command_line::arg_descriptor<bool> arg_db_salvage  = {
   "db-salvage"

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1262,23 +1262,6 @@ public:
   virtual output_data_t get_output_key(const uint64_t& amount, const uint64_t& index) = 0;
 
   /**
-   * @brief get some of an output's data
-   *
-   * The subclass should return the public key, unlock time, and block height
-   * for the output with the given global index, collected in a struct.
-   *
-   * If the output cannot be found, the subclass should throw OUTPUT_DNE.
-   *
-   * If any of these parts cannot be found, but some are, the subclass
-   * should throw DB_ERROR with a message stating as much.
-   *
-   * @param global_index the output's index (global)
-   *
-   * @return the requested output data
-   */
-  virtual output_data_t get_output_key(const uint64_t& global_index) const = 0;
-
-  /**
    * @brief gets an output's tx hash and index
    *
    * The subclass should return the hash of the transaction which created the

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2985,10 +2985,10 @@ void BlockchainLMDB::set_batch_transactions(bool batch_transactions)
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   if ((batch_transactions) && (m_batch_transactions))
   {
-    LOG_PRINT_L0("WARNING: batch transaction mode already enabled, but asked to enable batch mode");
+    MINFO("batch transaction mode already enabled, but asked to enable batch mode");
   }
   m_batch_transactions = batch_transactions;
-  LOG_PRINT_L3("batch transactions " << (m_batch_transactions ? "enabled" : "disabled"));
+  MINFO("batch transactions " << (m_batch_transactions ? "enabled" : "disabled"));
 }
 
 // return true if we started the txn, false if already started

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -243,7 +243,6 @@ public:
   virtual uint64_t get_num_outputs(const uint64_t& amount) const;
 
   virtual output_data_t get_output_key(const uint64_t& amount, const uint64_t& index);
-  virtual output_data_t get_output_key(const uint64_t& global_index) const;
   virtual void get_output_key(const uint64_t &amount, const std::vector<uint64_t> &offsets, std::vector<output_data_t> &outputs, bool allow_partial = false);
 
   virtual tx_out_index get_output_tx_and_index_from_global(const uint64_t& index) const;

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -441,7 +441,6 @@ int main(int argc, char* argv[])
           MINFO("Blackballing output " << pkey << ", due to being used in a 1-ring");
           ringdb.blackball(pkey);
           newly_spent.insert(output_data(txin.amount, absolute[0]));
-          state.spent.insert(output_data(txin.amount, absolute[0]));
         }
         else if (state.ring_instances[new_ring] == new_ring.size())
         {
@@ -451,7 +450,6 @@ int main(int argc, char* argv[])
             MINFO("Blackballing output " << pkey << ", due to being used in " << new_ring.size() << " identical " << new_ring.size() << "-rings");
             ringdb.blackball(pkey);
             newly_spent.insert(output_data(txin.amount, absolute[o]));
-            state.spent.insert(output_data(txin.amount, absolute[o]));
           }
         }
         else if (state.relative_rings.find(txin.k_image) != state.relative_rings.end())
@@ -480,7 +478,6 @@ int main(int argc, char* argv[])
               MINFO("Blackballing output " << pkey << ", due to being used in rings with a single common element");
               ringdb.blackball(pkey);
               newly_spent.insert(output_data(txin.amount, common[0]));
-              state.spent.insert(output_data(txin.amount, common[0]));
             }
             else
             {
@@ -513,6 +510,9 @@ int main(int argc, char* argv[])
     std::unordered_set<output_data> work_spent = std::move(newly_spent);
     newly_spent.clear();
 
+    for (const auto &e: work_spent)
+      state.spent.insert(e);
+
     for (const output_data &od: work_spent)
     {
       for (const crypto::key_image &ki: state.outputs[od])
@@ -535,7 +535,6 @@ int main(int argc, char* argv[])
               absolute.size() << "-ring where all other outputs are known to be spent");
           ringdb.blackball(pkey);
           newly_spent.insert(output_data(od.amount, last_unknown));
-          state.spent.insert(output_data(od.amount, last_unknown));
         }
       }
     }

--- a/src/common/password.cpp
+++ b/src/common/password.cpp
@@ -54,7 +54,7 @@ namespace
     return 0 != _isatty(_fileno(stdin));
   }
 
-  bool read_from_tty(epee::wipeable_string& pass)
+  bool read_from_tty(epee::wipeable_string& pass, bool hide_input)
   {
     static constexpr const char BACKSPACE = 8;
 
@@ -62,7 +62,7 @@ namespace
 
     DWORD mode_old;
     ::GetConsoleMode(h_cin, &mode_old);
-    DWORD mode_new = mode_old & ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT);
+    DWORD mode_new = mode_old & ~((hide_input ? ENABLE_ECHO_INPUT : 0) | ENABLE_LINE_INPUT);
     ::SetConsoleMode(h_cin, mode_new);
 
     bool r = true;
@@ -107,14 +107,14 @@ namespace
     return 0 != isatty(fileno(stdin));
   }
 
-  int getch() noexcept
+  int getch(bool hide_input) noexcept
   {
     struct termios tty_old;
     tcgetattr(STDIN_FILENO, &tty_old);
 
     struct termios tty_new;
     tty_new = tty_old;
-    tty_new.c_lflag &= ~(ICANON | ECHO);
+    tty_new.c_lflag &= ~(ICANON | (hide_input ? ECHO : 0));
     tcsetattr(STDIN_FILENO, TCSANOW, &tty_new);
 
     int ch = getchar();
@@ -124,14 +124,14 @@ namespace
     return ch;
   }
 
-  bool read_from_tty(epee::wipeable_string& aPass)
+  bool read_from_tty(epee::wipeable_string& aPass, bool hide_input)
   {
     static constexpr const char BACKSPACE = 127;
 
     aPass.reserve(tools::password_container::max_password_size);
     while (aPass.size() < tools::password_container::max_password_size)
     {
-      int ch = getch();
+      int ch = getch(hide_input);
       if (EOF == ch || ch == EOT)
       {
         return false;
@@ -159,18 +159,18 @@ namespace
 
 #endif // end !WIN32
 
-  bool read_from_tty(const bool verify, const char *message, epee::wipeable_string& pass1, epee::wipeable_string& pass2)
+  bool read_from_tty(const bool verify, const char *message, bool hide_input, epee::wipeable_string& pass1, epee::wipeable_string& pass2)
   {
     while (true)
     {
       if (message)
         std::cout << message <<": " << std::flush;
-      if (!read_from_tty(pass1))
+      if (!read_from_tty(pass1, hide_input))
         return false;
       if (verify)
       {
         std::cout << "Confirm password: ";
-        if (!read_from_tty(pass2))
+        if (!read_from_tty(pass2, hide_input))
           return false;
         if(pass1!=pass2)
         {
@@ -229,12 +229,12 @@ namespace tools
 
   std::atomic<bool> password_container::is_prompting(false);
 
-  boost::optional<password_container> password_container::prompt(const bool verify, const char *message)
+  boost::optional<password_container> password_container::prompt(const bool verify, const char *message, bool hide_input)
   {
     is_prompting = true;
     password_container pass1{};
     password_container pass2{};
-    if (is_cin_tty() ? read_from_tty(verify, message, pass1.m_password, pass2.m_password) : read_from_file(pass1.m_password))
+    if (is_cin_tty() ? read_from_tty(verify, message, hide_input, pass1.m_password, pass2.m_password) : read_from_file(pass1.m_password))
     {
       is_prompting = false;
       return {std::move(pass1)};

--- a/src/common/password.h
+++ b/src/common/password.h
@@ -49,7 +49,7 @@ namespace tools
     password_container(std::string&& password) noexcept;
 
     //! \return A password from stdin TTY prompt or `std::cin` pipe.
-    static boost::optional<password_container> prompt(bool verify, const char *mesage = "Password");
+    static boost::optional<password_container> prompt(bool verify, const char *mesage = "Password", bool hide_input = true);
     static std::atomic<bool> is_prompting;
 
     password_container(const password_container&) = delete;

--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -49,7 +49,16 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "stacktrace"
 
-#define ST_LOG(x) CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,MONERO_DEFAULT_LOG_CATEGORY) << x
+#define ST_LOG(x) \
+  do { \
+    auto elpp = ELPP; \
+    if (elpp) { \
+      CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,MONERO_DEFAULT_LOG_CATEGORY) << x; \
+    } \
+    else { \
+      std::cout << x << std::endl; \
+    } \
+  } while(0)
 
 // from https://stackoverflow.com/questions/11665829/how-can-i-print-stack-trace-for-caught-exceptions-in-c-code-injection-in-c
 

--- a/src/common/updates.cpp
+++ b/src/common/updates.cpp
@@ -72,12 +72,12 @@ namespace tools
         continue;
 
       bool alnum = true;
-      for (auto c: hash)
+      for (auto c: fields[3])
         if (!isalnum(c))
           alnum = false;
-      if (hash.size() != 64 && !alnum)
+      if (fields[3].size() != 64 && !alnum)
       {
-        MWARNING("Invalid hash: " << hash);
+        MWARNING("Invalid hash: " << fields[3]);
         continue;
       }
 

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -37,6 +37,7 @@
 #ifdef __GLIBC__
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <string.h>
@@ -706,6 +707,21 @@ std::string get_nix_version_display_string()
 #else
   static void setup_crash_dump() {}
 #endif
+
+  bool disable_core_dumps()
+  {
+#ifdef __GLIBC__
+    // disable core dumps in release mode
+    struct rlimit rlimit;
+    rlimit.rlim_cur = rlimit.rlim_max = 0;
+    if (setrlimit(RLIMIT_CORE, &rlimit))
+    {
+      MWARNING("Failed to disable core dumps");
+      return false;
+    }
+#endif
+    return true;
+  }
 
   bool on_startup()
   {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -149,6 +149,8 @@ namespace tools
 
   bool sanitize_locale();
 
+  bool disable_core_dumps();
+
   bool on_startup();
 
   /*! \brief Defines a signal handler for win32 and *nix

--- a/src/crypto/chacha.h
+++ b/src/crypto/chacha.h
@@ -69,22 +69,26 @@ namespace crypto {
     chacha20(data, length, key.data(), reinterpret_cast<const uint8_t*>(&iv), cipher);
   }
 
-  inline void generate_chacha_key(const void *data, size_t size, chacha_key& key) {
+  inline void generate_chacha_key(const void *data, size_t size, chacha_key& key, uint64_t kdf_rounds) {
     static_assert(sizeof(chacha_key) <= sizeof(hash), "Size of hash must be at least that of chacha_key");
     tools::scrubbed_arr<char, HASH_SIZE> pwd_hash;
     crypto::cn_slow_hash(data, size, pwd_hash.data(), 0/*light*/, 0/*variant*/, 0/*prehashed*/);
+    for (uint64_t n = 1; n < kdf_rounds; ++n)
+      crypto::cn_slow_hash(pwd_hash.data(), pwd_hash.size(), pwd_hash.data(), 0/*light*/, 0/*variant*/, 0/*prehashed*/);
     memcpy(&unwrap(key), pwd_hash.data(), sizeof(key));
   }
 
-  inline void generate_chacha_key_prehashed(const void *data, size_t size, chacha_key& key) {
+  inline void generate_chacha_key_prehashed(const void *data, size_t size, chacha_key& key, uint64_t kdf_rounds) {
     static_assert(sizeof(chacha_key) <= sizeof(hash), "Size of hash must be at least that of chacha_key");
     tools::scrubbed_arr<char, HASH_SIZE> pwd_hash;
     crypto::cn_slow_hash(data, size, pwd_hash.data(), 0/*light*/, 0/*variant*/, 1/*prehashed*/);
+    for (uint64_t n = 1; n < kdf_rounds; ++n)
+      crypto::cn_slow_hash(pwd_hash.data(), pwd_hash.size(), pwd_hash.data(), 0/*light*/, 0/*variant*/, 0/*prehashed*/);
     memcpy(&unwrap(key), pwd_hash.data(), sizeof(key));
   }
 
-  inline void generate_chacha_key(std::string password, chacha_key& key) {
-    return generate_chacha_key(password.data(), password.size(), key);
+  inline void generate_chacha_key(std::string password, chacha_key& key, uint64_t kdf_rounds) {
+    return generate_chacha_key(password.data(), password.size(), key, kdf_rounds);
   }
 }
 

--- a/src/crypto/chacha.h
+++ b/src/crypto/chacha.h
@@ -40,6 +40,7 @@
 #include <memory.h>
 
 #include "memwipe.h"
+#include "mlocker.h"
 #include "hash.h"
 
 namespace crypto {
@@ -50,7 +51,7 @@ namespace crypto {
 #if defined(__cplusplus)
   }
 
-  using chacha_key = tools::scrubbed_arr<uint8_t, CHACHA_KEY_SIZE>;
+  using chacha_key = epee::mlocked<tools::scrubbed_arr<uint8_t, CHACHA_KEY_SIZE>>;
 
 #pragma pack(push, 1)
   // MS VC 2012 doesn't interpret `class chacha_iv` as POD in spite of [9.0.10], so it is a struct
@@ -71,20 +72,20 @@ namespace crypto {
 
   inline void generate_chacha_key(const void *data, size_t size, chacha_key& key, uint64_t kdf_rounds) {
     static_assert(sizeof(chacha_key) <= sizeof(hash), "Size of hash must be at least that of chacha_key");
-    tools::scrubbed_arr<char, HASH_SIZE> pwd_hash;
+    epee::mlocked<tools::scrubbed_arr<char, HASH_SIZE>> pwd_hash;
     crypto::cn_slow_hash(data, size, pwd_hash.data(), 0/*light*/, 0/*variant*/, 0/*prehashed*/);
     for (uint64_t n = 1; n < kdf_rounds; ++n)
       crypto::cn_slow_hash(pwd_hash.data(), pwd_hash.size(), pwd_hash.data(), 0/*light*/, 0/*variant*/, 0/*prehashed*/);
-    memcpy(&unwrap(key), pwd_hash.data(), sizeof(key));
+    memcpy(&unwrap(unwrap(key)), pwd_hash.data(), sizeof(key));
   }
 
   inline void generate_chacha_key_prehashed(const void *data, size_t size, chacha_key& key, uint64_t kdf_rounds) {
     static_assert(sizeof(chacha_key) <= sizeof(hash), "Size of hash must be at least that of chacha_key");
-    tools::scrubbed_arr<char, HASH_SIZE> pwd_hash;
+    epee::mlocked<tools::scrubbed_arr<char, HASH_SIZE>> pwd_hash;
     crypto::cn_slow_hash(data, size, pwd_hash.data(), 0/*light*/, 0/*variant*/, 1/*prehashed*/);
     for (uint64_t n = 1; n < kdf_rounds; ++n)
       crypto::cn_slow_hash(pwd_hash.data(), pwd_hash.size(), pwd_hash.data(), 0/*light*/, 0/*variant*/, 0/*prehashed*/);
-    memcpy(&unwrap(key), pwd_hash.data(), sizeof(key));
+    memcpy(&unwrap(unwrap(key)), pwd_hash.data(), sizeof(key));
   }
 
   inline void generate_chacha_key(std::string password, chacha_key& key, uint64_t kdf_rounds) {

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -70,8 +70,8 @@ namespace crypto {
 #include "random.h"
   }
 
-  const crypto::public_key null_pkey = boost::value_initialized<crypto::public_key>();
-  const crypto::secret_key null_skey = boost::value_initialized<crypto::secret_key>();
+  const crypto::public_key null_pkey = crypto::public_key{};
+  const crypto::secret_key null_skey = crypto::secret_key{};
 
   static inline unsigned char *operator &(ec_point &point) {
     return &reinterpret_cast<unsigned char &>(point);

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -70,6 +70,9 @@ namespace crypto {
 #include "random.h"
   }
 
+  const crypto::public_key null_pkey = boost::value_initialized<crypto::public_key>();
+  const crypto::secret_key null_skey = boost::value_initialized<crypto::secret_key>();
+
   static inline unsigned char *operator &(ec_point &point) {
     return &reinterpret_cast<unsigned char &>(point);
   }

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -41,6 +41,7 @@
 #include "common/pod-class.h"
 #include "common/util.h"
 #include "memwipe.h"
+#include "mlocker.h"
 #include "generic-ops.h"
 #include "hex.h"
 #include "span.h"
@@ -65,7 +66,7 @@ namespace crypto {
     friend class crypto_ops;
   };
 
-  using secret_key = tools::scrubbed<ec_scalar>;
+  using secret_key = epee::mlocked<tools::scrubbed<ec_scalar>>;
 
   POD_CLASS public_keyV {
     std::vector<public_key> keys;

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -283,6 +283,6 @@ namespace crypto {
 }
 
 CRYPTO_MAKE_HASHABLE(public_key)
-CRYPTO_MAKE_HASHABLE(secret_key)
+CRYPTO_MAKE_HASHABLE_CONSTANT_TIME(secret_key)
 CRYPTO_MAKE_HASHABLE(key_image)
 CRYPTO_MAKE_COMPARABLE(signature)

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -34,7 +34,6 @@
 #include <iostream>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
-#include <boost/utility/value_init.hpp>
 #include <boost/optional.hpp>
 #include <type_traits>
 #include <vector>

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -278,8 +278,8 @@ namespace crypto {
     epee::to_hex::formatted(o, epee::as_byte_span(v)); return o;
   }
 
-  const static crypto::public_key null_pkey = boost::value_initialized<crypto::public_key>();
-  const static crypto::secret_key null_skey = boost::value_initialized<crypto::secret_key>();
+  const extern crypto::public_key null_pkey;
+  const extern crypto::secret_key null_skey;
 }
 
 CRYPTO_MAKE_HASHABLE(public_key)

--- a/src/crypto/generic-ops.h
+++ b/src/crypto/generic-ops.h
@@ -38,10 +38,6 @@
 #define CRYPTO_MAKE_COMPARABLE(type) \
 namespace crypto { \
   inline bool operator==(const type &_v1, const type &_v2) { \
-    if (sizeof(_v1) == 32) \
-      return crypto_verify_32((const unsigned char*)&_v1, (const unsigned char*)&_v2) == 0; \
-    if (sizeof(_v1) == 8) \
-      return (const uint64_t&)_v1 == (const uint64_t&)_v2; \
     return !memcmp(&_v1, &_v2, sizeof(_v1)); \
   } \
   inline bool operator!=(const type &_v1, const type &_v2) { \
@@ -49,8 +45,18 @@ namespace crypto { \
   } \
 }
 
-#define CRYPTO_MAKE_HASHABLE(type) \
-CRYPTO_MAKE_COMPARABLE(type) \
+#define CRYPTO_MAKE_COMPARABLE_CONSTANT_TIME(type) \
+namespace crypto { \
+  inline bool operator==(const type &_v1, const type &_v2) { \
+    static_assert(sizeof(_v1) == 32, "constant time comparison is only implenmted for 32 bytes"); \
+    return crypto_verify_32((const unsigned char*)&_v1, (const unsigned char*)&_v2) == 0; \
+  } \
+  inline bool operator!=(const type &_v1, const type &_v2) { \
+    return !operator==(_v1, _v2); \
+  } \
+}
+
+#define CRYPTO_DEFINE_HASH_FUNCTIONS(type) \
 namespace crypto { \
   static_assert(sizeof(std::size_t) <= sizeof(type), "Size of " #type " must be at least that of size_t"); \
   inline std::size_t hash_value(const type &_v) { \
@@ -65,3 +71,12 @@ namespace std { \
     } \
   }; \
 }
+
+#define CRYPTO_MAKE_HASHABLE(type) \
+CRYPTO_MAKE_COMPARABLE(type) \
+CRYPTO_DEFINE_HASH_FUNCTIONS(type)
+
+#define CRYPTO_MAKE_HASHABLE_CONSTANT_TIME(type) \
+CRYPTO_MAKE_COMPARABLE_CONSTANT_TIME(type) \
+CRYPTO_DEFINE_HASH_FUNCTIONS(type)
+

--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -67,7 +67,7 @@ DISABLE_VS_WARNINGS(4244 4345)
   static void derive_key(const crypto::chacha_key &base_key, crypto::chacha_key &key)
   {
     static_assert(sizeof(base_key) == sizeof(crypto::hash), "chacha key and hash should be the same size");
-    tools::scrubbed_arr<char, sizeof(base_key)+1> data;
+    epee::mlocked<tools::scrubbed_arr<char, sizeof(base_key)+1>> data;
     memcpy(data.data(), &base_key, sizeof(base_key));
     data[sizeof(base_key)] = KEYS_ENCRYPTION_SALT;
     crypto::generate_chacha_key(data.data(), sizeof(data), key, 1);
@@ -223,7 +223,7 @@ DISABLE_VS_WARNINGS(4244 4345)
   void account_base::create_from_viewkey(const cryptonote::account_public_address& address, const crypto::secret_key& viewkey)
   {
     crypto::secret_key fake;
-    memset(&unwrap(fake), 0, sizeof(fake));
+    memset(&unwrap(unwrap(fake)), 0, sizeof(fake));
     create_from_keys(address, fake, viewkey);
   }
   //-----------------------------------------------------------------

--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -44,6 +44,9 @@ extern "C"
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "account"
 
+#define KEYS_ENCRYPTION_SALT 'k'
+
+
 using namespace std;
 
 DISABLE_VS_WARNINGS(4244 4345)
@@ -60,7 +63,70 @@ DISABLE_VS_WARNINGS(4244 4345)
     m_device = &hwdev;
     MCDEBUG("device", "account_keys::set_device device type: "<<typeid(hwdev).name());
   }
+  //-----------------------------------------------------------------
+  static void derive_key(const crypto::chacha_key &base_key, crypto::chacha_key &key)
+  {
+    static_assert(sizeof(base_key) == sizeof(crypto::hash), "chacha key and hash should be the same size");
+    tools::scrubbed_arr<char, sizeof(base_key)+1> data;
+    memcpy(data.data(), &base_key, sizeof(base_key));
+    data[sizeof(base_key)] = KEYS_ENCRYPTION_SALT;
+    crypto::generate_chacha_key(data.data(), sizeof(data), key, 1);
+  }
+  //-----------------------------------------------------------------
+  static epee::wipeable_string get_key_stream(const crypto::chacha_key &base_key, const crypto::chacha_iv &iv, size_t bytes)
+  {
+    // derive a new key
+    crypto::chacha_key key;
+    derive_key(base_key, key);
 
+    // chacha
+    epee::wipeable_string buffer0(std::string(bytes, '\0'));
+    epee::wipeable_string buffer1 = buffer0;
+    crypto::chacha20(buffer0.data(), buffer0.size(), key, iv, buffer1.data());
+    return buffer1;
+  }
+  //-----------------------------------------------------------------
+  void account_keys::xor_with_key_stream(const crypto::chacha_key &key)
+  {
+    // encrypt a large enough byte stream with chacha20
+    epee::wipeable_string key_stream = get_key_stream(key, m_encryption_iv, sizeof(crypto::secret_key) * (2 + m_multisig_keys.size()));
+    const char *ptr = key_stream.data();
+    for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
+      m_spend_secret_key.data[i] ^= *ptr++;
+    for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
+      m_view_secret_key.data[i] ^= *ptr++;
+    for (crypto::secret_key &k: m_multisig_keys)
+    {
+      for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
+        k.data[i] ^= *ptr++;
+    }
+  }
+  //-----------------------------------------------------------------
+  void account_keys::encrypt(const crypto::chacha_key &key)
+  {
+    m_encryption_iv = crypto::rand<crypto::chacha_iv>();
+    xor_with_key_stream(key);
+  }
+  //-----------------------------------------------------------------
+  void account_keys::decrypt(const crypto::chacha_key &key)
+  {
+    xor_with_key_stream(key);
+  }
+  //-----------------------------------------------------------------
+  void account_keys::encrypt_viewkey(const crypto::chacha_key &key)
+  {
+    // encrypt a large enough byte stream with chacha20
+    epee::wipeable_string key_stream = get_key_stream(key, m_encryption_iv, sizeof(crypto::secret_key) * 2);
+    const char *ptr = key_stream.data();
+    ptr += sizeof(crypto::secret_key);
+    for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
+      m_view_secret_key.data[i] ^= *ptr++;
+  }
+  //-----------------------------------------------------------------
+  void account_keys::decrypt_viewkey(const crypto::chacha_key &key)
+  {
+    encrypt_viewkey(key);
+  }
   //-----------------------------------------------------------------
   account_base::account_base()
   {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4091,6 +4091,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   TIME_MEASURE_START(prepare);
   bool stop_batch;
   uint64_t bytes = 0;
+  size_t total_txs = 0;
 
   // Order of locking must be:
   //  m_incoming_tx_lock (optional)
@@ -4119,6 +4120,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
     {
       bytes += tx_blob.size();
     }
+    total_txs += entry.txs.size();
   }
   while (!(stop_batch = m_db->batch_start(blocks_entry.size(), bytes))) {
     m_blockchain_lock.unlock();
@@ -4178,7 +4180,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
           break;
         }
 
-        blocks[i].push_back(block);
+        blocks[i].push_back(std::move(block));
         std::advance(it, 1);
       }
     }
@@ -4199,7 +4201,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
         break;
       }
 
-      blocks[i].push_back(block);
+      blocks[i].push_back(std::move(block));
       std::advance(it, 1);
     }
 
@@ -4255,6 +4257,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   std::map<uint64_t, std::vector<uint64_t>> offset_map;
   // [output] stores all output_data_t for each absolute_offset
   std::map<uint64_t, std::vector<output_data_t>> tx_map;
+  std::vector<std::pair<cryptonote::transaction, crypto::hash>> txes(total_txs);
 
 #define SCAN_TABLE_QUIT(m) \
         do { \
@@ -4264,6 +4267,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
         } while(0); \
 
   // generate sorted tables for all amounts and absolute offsets
+  size_t tx_index = 0;
   for (const auto &entry : blocks_entry)
   {
     if (m_cancel)
@@ -4271,12 +4275,15 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
 
     for (const auto &tx_blob : entry.txs)
     {
-      crypto::hash tx_hash = null_hash;
-      crypto::hash tx_prefix_hash = null_hash;
-      transaction tx;
+      if (tx_index >= txes.size())
+        SCAN_TABLE_QUIT("tx_index is out of sync");
+      transaction &tx = txes[tx_index].first;
+      crypto::hash &tx_prefix_hash = txes[tx_index].second;
+      ++tx_index;
 
-      if (!parse_and_validate_tx_from_blob(tx_blob, tx, tx_hash, tx_prefix_hash))
+      if (!parse_and_validate_tx_base_from_blob(tx_blob, tx))
         SCAN_TABLE_QUIT("Could not parse tx from incoming blocks.");
+      cryptonote::get_transaction_prefix_hash(tx, tx_prefix_hash);
 
       auto its = m_scan_table.find(tx_prefix_hash);
       if (its != m_scan_table.end())
@@ -4362,9 +4369,8 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
     }
   }
 
-  int total_txs = 0;
-
   // now generate a table for each tx_prefix and k_image hashes
+  tx_index = 0;
   for (const auto &entry : blocks_entry)
   {
     if (m_cancel)
@@ -4372,14 +4378,12 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
 
     for (const auto &tx_blob : entry.txs)
     {
-      crypto::hash tx_hash = null_hash;
-      crypto::hash tx_prefix_hash = null_hash;
-      transaction tx;
+      if (tx_index >= txes.size())
+        SCAN_TABLE_QUIT("tx_index is out of sync");
+      const transaction &tx = txes[tx_index].first;
+      const crypto::hash &tx_prefix_hash = txes[tx_index].second;
+      ++tx_index;
 
-      if (!parse_and_validate_tx_from_blob(tx_blob, tx, tx_hash, tx_prefix_hash))
-        SCAN_TABLE_QUIT("Could not parse tx from incoming blocks.");
-
-      ++total_txs;
       auto its = m_scan_table.find(tx_prefix_hash);
       if (its == m_scan_table.end())
         SCAN_TABLE_QUIT("Tx not found on scan table from incoming blocks.");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2299,7 +2299,7 @@ bool Blockchain::find_blockchain_supplement(const uint64_t req_start_block, cons
   total_height = get_current_blockchain_height();
   size_t count = 0, size = 0;
   blocks.reserve(std::min(std::min(max_count, (size_t)10000), (size_t)(total_height - start_height)));
-  for(size_t i = start_height; i < total_height && count < max_count && (size < FIND_BLOCKCHAIN_SUPPLEMENT_MAX_SIZE || count < 3); i++, count++)
+  for(uint64_t i = start_height; i < total_height && count < max_count && (size < FIND_BLOCKCHAIN_SUPPLEMENT_MAX_SIZE || count < 3); i++, count++)
   {
     blocks.resize(blocks.size()+1);
     blocks.back().first.first = m_db->get_block_blob_from_height(i);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -133,7 +133,7 @@ static const struct {
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
   m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_timestamps_and_difficulties_height(0), m_current_block_cumul_sz_limit(0), m_current_block_cumul_sz_median(0),
-  m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_blocks_per_sync(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_cancel(false),
+  m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_bytes_to_sync(0), m_cancel(false),
   m_difficulty_for_next_block_top_hash(crypto::null_hash),
   m_difficulty_for_next_block(1),
   m_btc_valid(false)
@@ -3926,11 +3926,13 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
         store_blockchain();
       m_sync_counter = 0;
     }
-    else if (m_db_blocks_per_sync && m_sync_counter >= m_db_blocks_per_sync)
+    else if (m_db_sync_threshold && ((m_db_sync_on_blocks && m_sync_counter >= m_db_sync_threshold) || (!m_db_sync_on_blocks && m_bytes_to_sync >= m_db_sync_threshold)))
     {
+      MDEBUG("Sync threshold met, syncing");
       if(m_db_sync_mode == db_async)
       {
         m_sync_counter = 0;
+        m_bytes_to_sync = 0;
         m_async_service.dispatch(boost::bind(&Blockchain::store_blockchain, this));
       }
       else if(m_db_sync_mode == db_sync)
@@ -4122,6 +4124,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
     }
     total_txs += entry.txs.size();
   }
+  m_bytes_to_sync += bytes;
   while (!(stop_batch = m_db->batch_start(blocks_entry.size(), bytes))) {
     m_blockchain_lock.unlock();
     m_tx_pool.unlock();
@@ -4472,7 +4475,7 @@ bool Blockchain::for_all_txpool_txes(std::function<bool(const crypto::hash&, con
   return m_db->for_all_txpool_txes(f, include_blob, include_unrelayed_txes);
 }
 
-void Blockchain::set_user_options(uint64_t maxthreads, uint64_t blocks_per_sync, blockchain_db_sync_mode sync_mode, bool fast_sync)
+void Blockchain::set_user_options(uint64_t maxthreads, bool sync_on_blocks, uint64_t sync_threshold, blockchain_db_sync_mode sync_mode, bool fast_sync)
 {
   if (sync_mode == db_defaultsync)
   {
@@ -4481,7 +4484,8 @@ void Blockchain::set_user_options(uint64_t maxthreads, uint64_t blocks_per_sync,
   }
   m_db_sync_mode = sync_mode;
   m_fast_sync = fast_sync;
-  m_db_blocks_per_sync = blocks_per_sync;
+  m_db_sync_on_blocks = sync_on_blocks;
+  m_db_sync_threshold = sync_threshold;
   m_max_prepare_blocks_threads = maxthreads;
 }
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -729,11 +729,12 @@ namespace cryptonote
      * @brief sets various performance options
      *
      * @param maxthreads max number of threads when preparing blocks for addition
-     * @param blocks_per_sync number of blocks to cache before syncing to database
+     * @param sync_on_blocks whether to sync based on blocks or bytes
+     * @param sync_threshold number of blocks/bytes to cache before syncing to database
      * @param sync_mode the ::blockchain_db_sync_mode to use
      * @param fast_sync sync using built-in block hashes as trusted
      */
-    void set_user_options(uint64_t maxthreads, uint64_t blocks_per_sync,
+    void set_user_options(uint64_t maxthreads, bool sync_on_blocks, uint64_t sync_threshold,
         blockchain_db_sync_mode sync_mode, bool fast_sync);
 
     /**
@@ -1017,11 +1018,13 @@ namespace cryptonote
     bool m_fast_sync;
     bool m_show_time_stats;
     bool m_db_default_sync;
-    uint64_t m_db_blocks_per_sync;
+    bool m_db_sync_on_blocks;
+    uint64_t m_db_sync_threshold;
     uint64_t m_max_prepare_blocks_threads;
     uint64_t m_fake_pow_calc_time;
     uint64_t m_fake_scan_time;
     uint64_t m_sync_counter;
+    uint64_t m_bytes_to_sync;
     std::vector<uint64_t> m_timestamps;
     std::vector<difficulty_type> m_difficulties;
     uint64_t m_timestamps_and_difficulties_height;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1168,8 +1168,20 @@ skip:
                 + " blocks/sec), " + std::to_string(m_block_queue.get_data_size() / 1048576.f) + " MB queued";
             if (ELPP->vRegistry()->allowed(el::Level::Debug, "sync-info"))
               timing_message += std::string(": ") + m_block_queue.get_overview();
-            MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
+            if(m_core.get_target_blockchain_height() == 0){
+              MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
                 << timing_message);
+            } else {
+              const int completition_percent = (m_core.get_current_blockchain_height() * 100 / m_core.get_target_blockchain_height());
+              if(completition_percent < 99) {//printing completion percent only if % is < of 99 cause for 99 >= this is useless
+                MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
+                  << " (" << completition_percent << "% " << (m_core.get_target_blockchain_height() - m_core.get_current_blockchain_height())
+                  << " blocks remaining)" << timing_message);
+              } else {
+                MGINFO_YELLOW(context << " Synced " << m_core.get_current_blockchain_height() << "/" << m_core.get_target_blockchain_height()
+                  << timing_message);
+              }
+            }
           }
         }
       }
@@ -1753,3 +1765,4 @@ skip:
     m_core.stop();
   }
 } // namespace
+

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -557,7 +557,7 @@ bool t_rpc_command_executor::print_blockchain_info(uint64_t start_block_index, u
     if (!first)
       std::cout << std::endl;
     std::cout
-      << "height: " << header.height << ", timestamp: " << header.timestamp << ", difficulty: " << header.difficulty
+      << "height: " << header.height << ", timestamp: " << header.timestamp
       << ", size: " << header.block_size << ", transactions: " << header.num_txes << std::endl
       << "major version: " << (unsigned)header.major_version << ", minor version: " << (unsigned)header.minor_version << std::endl
       << "block id: " << header.hash << ", previous block id: " << header.prev_hash << std::endl

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -125,7 +125,7 @@ namespace hw {
         /* ======================================================================= */
         virtual bool  get_public_address(cryptonote::account_public_address &pubkey) = 0;
         virtual bool  get_secret_keys(crypto::secret_key &viewkey , crypto::secret_key &spendkey)  = 0;
-        virtual bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key) = 0;
+        virtual bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) = 0;
 
         /* ======================================================================= */
         /*                               SUB ADDRESS                               */

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -100,14 +100,14 @@ namespace hw {
         /*                             WALLET & ADDRESS                            */
         /* ======================================================================= */
 
-        bool  device_default::generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key) {
+        bool  device_default::generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) {
             const crypto::secret_key &view_key = keys.m_view_secret_key;
             const crypto::secret_key &spend_key = keys.m_spend_secret_key;
             tools::scrubbed_arr<char, sizeof(view_key) + sizeof(spend_key) + 1> data;
             memcpy(data.data(), &view_key, sizeof(view_key));
             memcpy(data.data() + sizeof(view_key), &spend_key, sizeof(spend_key));
             data[sizeof(data) - 1] = CHACHA8_KEY_TAIL;
-            crypto::generate_chacha_key(data.data(), sizeof(data), key);
+            crypto::generate_chacha_key(data.data(), sizeof(data), key, kdf_rounds);
             return true;
         }
         bool  device_default::get_public_address(cryptonote::account_public_address &pubkey) {

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -103,7 +103,7 @@ namespace hw {
         bool  device_default::generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) {
             const crypto::secret_key &view_key = keys.m_view_secret_key;
             const crypto::secret_key &spend_key = keys.m_spend_secret_key;
-            tools::scrubbed_arr<char, sizeof(view_key) + sizeof(spend_key) + 1> data;
+            epee::mlocked<tools::scrubbed_arr<char, sizeof(view_key) + sizeof(spend_key) + 1>> data;
             memcpy(data.data(), &view_key, sizeof(view_key));
             memcpy(data.data() + sizeof(view_key), &spend_key, sizeof(spend_key));
             data[sizeof(data) - 1] = CHACHA8_KEY_TAIL;

--- a/src/device/device_default.hpp
+++ b/src/device/device_default.hpp
@@ -73,7 +73,7 @@ namespace hw {
             /* ======================================================================= */
             bool  get_public_address(cryptonote::account_public_address &pubkey) override;
             bool  get_secret_keys(crypto::secret_key &viewkey , crypto::secret_key &spendkey) override;
-            bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key) override;
+            bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) override;
  
             /* ======================================================================= */
             /*                               SUB ADDRESS                               */

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -532,20 +532,20 @@ namespace hw {
         return true;
     }
 
-    bool  device_ledger::generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key) {
+    bool  device_ledger::generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) {
         AUTO_LOCK_CMD();
 
         #ifdef DEBUG_HWDEVICE
         crypto::chacha_key key_x;
         cryptonote::account_keys keys_x = hw::ledger::decrypt(keys); 
-        this->controle_device->generate_chacha_key(keys_x, key_x);
+        this->controle_device->generate_chacha_key(keys_x, key_x, kdf_rounds);
         #endif
 
         send_simple(INS_GET_CHACHA8_PREKEY);
 
         char prekey[200];
         memmove(prekey, &this->buffer_recv[0], 200);
-        crypto::generate_chacha_key_prehashed(&prekey[0], sizeof(prekey), key);
+        crypto::generate_chacha_key_prehashed(&prekey[0], sizeof(prekey), key, kdf_rounds);
 
         #ifdef DEBUG_HWDEVICE
         hw::ledger::check32("generate_chacha_key_prehashed", "key", (char*)key_x.data(), (char*)key.data());

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -156,7 +156,7 @@ namespace hw {
         /* ======================================================================= */
         bool  get_public_address(cryptonote::account_public_address &pubkey) override;
         bool  get_secret_keys(crypto::secret_key &viewkey , crypto::secret_key &spendkey) override;
-        bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key) override;
+        bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) override;
 
 
         /* ======================================================================= */

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -92,7 +92,7 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
     {
       std::string name = basename + "-" + std::to_string(n + 1);
       wallets[n].reset(new tools::wallet2(nettype));
-      wallets[n]->init("");
+      wallets[n]->init(false, "");
       wallets[n]->generate(name, pwd_container->password(), rct::rct2sk(rct::skGen()), false, false, create_address_file);
     }
 
@@ -101,11 +101,13 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
     std::vector<crypto::public_key> pk(total);
     for (size_t n = 0; n < total; ++n)
     {
+      wallets[n]->decrypt_keys(pwd_container->password());
       if (!tools::wallet2::verify_multisig_info(wallets[n]->get_multisig_info(), sk[n], pk[n]))
       {
         tools::fail_msg_writer() << tr("Failed to verify multisig info");
         return false;
       }
+      wallets[n]->encrypt_keys(pwd_container->password());
     }
 
     // make the wallets multisig

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -70,6 +70,14 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "mnemonic"
 
+namespace crypto
+{
+  namespace ElectrumWords
+  {
+    std::vector<const Language::Base*> get_language_list();
+  }
+}
+
 namespace
 {
   uint32_t create_checksum_index(const std::vector<std::string> &word_list,
@@ -376,56 +384,14 @@ namespace crypto
 
       if (len % 4 != 0 || len == 0) return false;
 
-      Language::Base *language;
-      if (language_name == "English")
+      const Language::Base *language = NULL;
+      const std::vector<const Language::Base*> language_list = crypto::ElectrumWords::get_language_list();
+      for (const Language::Base *l: language_list)
       {
-        language = Language::Singleton<Language::English>::instance();
+        if (language_name == l->get_language_name() || language_name == l->get_english_language_name())
+          language = l;
       }
-      else if (language_name == "Nederlands")
-      {
-        language = Language::Singleton<Language::Dutch>::instance();
-      }
-      else if (language_name == "Français")
-      {
-        language = Language::Singleton<Language::French>::instance();
-      }
-      else if (language_name == "Español")
-      {
-        language = Language::Singleton<Language::Spanish>::instance();
-      }
-      else if (language_name == "Português")
-      {
-        language = Language::Singleton<Language::Portuguese>::instance();
-      }
-      else if (language_name == "日本語")
-      {
-        language = Language::Singleton<Language::Japanese>::instance();
-      }
-      else if (language_name == "Italiano")
-      {
-        language = Language::Singleton<Language::Italian>::instance();
-      }
-      else if (language_name == "Deutsch")
-      {
-        language = Language::Singleton<Language::German>::instance();
-      }
-      else if (language_name == "русский язык")
-      {
-        language = Language::Singleton<Language::Russian>::instance();
-      }
-      else if (language_name == "简体中文 (中国)")
-      {
-        language = Language::Singleton<Language::Chinese_Simplified>::instance();
-      }
-      else if (language_name == "Esperanto")
-      {
-        language = Language::Singleton<Language::Esperanto>::instance();
-      }
-      else if (language_name == "Lojban")
-      {
-        language = Language::Singleton<Language::Lojban>::instance();
-      }
-      else
+      if (!language)
       {
         return false;
       }

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -43,6 +43,8 @@
 #include <vector>
 #include <unordered_map>
 #include <boost/algorithm/string.hpp>
+#include "wipeable_string.h"
+#include "misc_language.h"
 #include "crypto/crypto.h"  // for declaration of crypto::secret_key
 #include <fstream>
 #include "mnemonics/electrum-words.h"
@@ -80,9 +82,9 @@ namespace crypto
 
 namespace
 {
-  uint32_t create_checksum_index(const std::vector<std::string> &word_list,
+  uint32_t create_checksum_index(const std::vector<epee::wipeable_string> &word_list,
     uint32_t unique_prefix_length);
-  bool checksum_test(std::vector<std::string> seed, uint32_t unique_prefix_length);
+  bool checksum_test(std::vector<epee::wipeable_string> seed, uint32_t unique_prefix_length);
 
   /*!
    * \brief Finds the word list that contains the seed words and puts the indices
@@ -93,7 +95,7 @@ namespace
    * \param  language        Language instance pointer to write to after it is found.
    * \return                 true if all the words were present in some language false if not.
    */
-  bool find_seed_language(const std::vector<std::string> &seed,
+  bool find_seed_language(const std::vector<epee::wipeable_string> &seed,
     bool has_checksum, std::vector<uint32_t> &matched_indices, Language::Base **language)
   {
     // If there's a new language added, add an instance of it here.
@@ -114,17 +116,19 @@ namespace
     });
     Language::Base *fallback = NULL;
 
+    std::vector<epee::wipeable_string>::const_iterator it2;
+    matched_indices.reserve(seed.size());
+
     // Iterate through all the languages and find a match
     for (std::vector<Language::Base*>::iterator it1 = language_instances.begin();
       it1 != language_instances.end(); it1++)
     {
-      const std::unordered_map<std::string, uint32_t> &word_map = (*it1)->get_word_map();
-      const std::unordered_map<std::string, uint32_t> &trimmed_word_map = (*it1)->get_trimmed_word_map();
+      const std::unordered_map<epee::wipeable_string, uint32_t> &word_map = (*it1)->get_word_map();
+      const std::unordered_map<epee::wipeable_string, uint32_t> &trimmed_word_map = (*it1)->get_trimmed_word_map();
       // To iterate through seed words
-      std::vector<std::string>::const_iterator it2;
       bool full_match = true;
 
-      std::string trimmed_word;
+      epee::wipeable_string trimmed_word;
       // Iterate through all the words and see if they're all present
       for (it2 = seed.begin(); it2 != seed.end(); it2++)
       {
@@ -167,6 +171,7 @@ namespace
         return true;
       }
       // Some didn't match. Clear the index array.
+      memwipe(matched_indices.data(), matched_indices.size() * sizeof(matched_indices[0]));
       matched_indices.clear();
     }
 
@@ -181,6 +186,7 @@ namespace
     }
 
     MINFO("No match found");
+    memwipe(matched_indices.data(), matched_indices.size() * sizeof(matched_indices[0]));
     return false;
   }
 
@@ -190,12 +196,12 @@ namespace
    * \param unique_prefix_length  the prefix length of each word to use for checksum
    * \return                      Checksum index
    */
-  uint32_t create_checksum_index(const std::vector<std::string> &word_list,
+  uint32_t create_checksum_index(const std::vector<epee::wipeable_string> &word_list,
     uint32_t unique_prefix_length)
   {
-    std::string trimmed_words = "";
+    epee::wipeable_string trimmed_words = "";
 
-    for (std::vector<std::string>::const_iterator it = word_list.begin(); it != word_list.end(); it++)
+    for (std::vector<epee::wipeable_string>::const_iterator it = word_list.begin(); it != word_list.end(); it++)
     {
       if (it->length() > unique_prefix_length)
       {
@@ -217,22 +223,22 @@ namespace
    * \param unique_prefix_length  the prefix length of each word to use for checksum
    * \return                      True if the test passed false if not.
    */
-  bool checksum_test(std::vector<std::string> seed, uint32_t unique_prefix_length)
+  bool checksum_test(std::vector<epee::wipeable_string> seed, uint32_t unique_prefix_length)
   {
     if (seed.empty())
       return false;
     // The last word is the checksum.
-    std::string last_word = seed.back();
+    epee::wipeable_string last_word = seed.back();
     seed.pop_back();
 
-    std::string checksum = seed[create_checksum_index(seed, unique_prefix_length)];
+    epee::wipeable_string checksum = seed[create_checksum_index(seed, unique_prefix_length)];
 
-    std::string trimmed_checksum = checksum.length() > unique_prefix_length ? Language::utf8prefix(checksum, unique_prefix_length) :
+    epee::wipeable_string trimmed_checksum = checksum.length() > unique_prefix_length ? Language::utf8prefix(checksum, unique_prefix_length) :
       checksum;
-    std::string trimmed_last_word = last_word.length() > unique_prefix_length ? Language::utf8prefix(last_word, unique_prefix_length) :
+    epee::wipeable_string trimmed_last_word = last_word.length() > unique_prefix_length ? Language::utf8prefix(last_word, unique_prefix_length) :
       last_word;
     bool ret = trimmed_checksum == trimmed_last_word;
-    MINFO("Checksum is %s" << (ret ? "valid" : "invalid"));
+    MINFO("Checksum is " << (ret ? "valid" : "invalid"));
     return ret;
   }
 }
@@ -260,13 +266,12 @@ namespace crypto
      * \param  language_name   Language of the seed as found gets written here.
      * \return                 false if not a multiple of 3 words, or if word is not in the words list
      */
-    bool words_to_bytes(std::string words, std::string& dst, size_t len, bool duplicate,
+    bool words_to_bytes(const epee::wipeable_string &words, epee::wipeable_string& dst, size_t len, bool duplicate,
       std::string &language_name)
     {
-      std::vector<std::string> seed;
+      std::vector<epee::wipeable_string> seed;
 
-      boost::algorithm::trim(words);
-      boost::split(seed, words, boost::is_any_of(" "), boost::token_compress_on);
+      words.split(seed);
 
       if (len % 4)
       {
@@ -291,6 +296,7 @@ namespace crypto
       }
 
       std::vector<uint32_t> matched_indices;
+      auto wiper = epee::misc_utils::create_scope_leave_handler([&](){memwipe(matched_indices.data(), matched_indices.size() * sizeof(matched_indices[0]));});
       Language::Base *language;
       if (!find_seed_language(seed, has_checksum, matched_indices, &language))
       {
@@ -313,33 +319,33 @@ namespace crypto
 
       for (unsigned int i=0; i < seed.size() / 3; i++)
       {
-        uint32_t val;
-        uint32_t w1, w2, w3;
-        w1 = matched_indices[i*3];
-        w2 = matched_indices[i*3 + 1];
-        w3 = matched_indices[i*3 + 2];
+        uint32_t w[4];
+        w[1] = matched_indices[i*3];
+        w[2] = matched_indices[i*3 + 1];
+        w[3] = matched_indices[i*3 + 2];
 
-        val = w1 + word_list_length * (((word_list_length - w1) + w2) % word_list_length) +
-          word_list_length * word_list_length * (((word_list_length - w2) + w3) % word_list_length);
+        w[0]= w[1] + word_list_length * (((word_list_length - w[1]) + w[2]) % word_list_length) +
+          word_list_length * word_list_length * (((word_list_length - w[2]) + w[3]) % word_list_length);
 
-        if (!(val % word_list_length == w1))
+        if (!(w[0]% word_list_length == w[1]))
         {
+          memwipe(w, sizeof(w));
           MERROR("Invalid seed: mumble mumble");
           return false;
         }
 
-        dst.append((const char*)&val, 4);  // copy 4 bytes to position
+        dst.append((const char*)&w[0], 4);  // copy 4 bytes to position
+        memwipe(w, sizeof(w));
       }
 
       if (len > 0 && duplicate)
       {
         const size_t expected = len * 3 / 32;
-        std::string wlist_copy = words;
         if (seed.size() == expected/2)
         {
-          dst.append(dst);                    // if electrum 12-word seed, duplicate
-          wlist_copy += ' ';
-          wlist_copy += words;
+          dst += ' ';                    // if electrum 12-word seed, duplicate
+          dst += dst;                    // if electrum 12-word seed, duplicate
+          dst.pop_back();                // trailing space
         }
       }
 
@@ -353,10 +359,10 @@ namespace crypto
      * \param  language_name   Language of the seed as found gets written here.
      * \return                 false if not a multiple of 3 words, or if word is not in the words list
      */
-    bool words_to_bytes(std::string words, crypto::secret_key& dst,
+    bool words_to_bytes(const epee::wipeable_string &words, crypto::secret_key& dst,
       std::string &language_name)
     {
-      std::string s;
+      epee::wipeable_string s;
       if (!words_to_bytes(words, s, sizeof(dst), true, language_name))
       {
         MERROR("Invalid seed: failed to convert words to bytes");
@@ -378,7 +384,7 @@ namespace crypto
      * \param  language_name Seed language name
      * \return               true if successful false if not. Unsuccessful if wrong key size.
      */
-    bool bytes_to_words(const char *src, size_t len, std::string& words,
+    bool bytes_to_words(const char *src, size_t len, epee::wipeable_string& words,
       const std::string &language_name)
     {
 
@@ -397,39 +403,38 @@ namespace crypto
       }
       const std::vector<std::string> &word_list = language->get_word_list();
       // To store the words for random access to add the checksum word later.
-      std::vector<std::string> words_store;
+      std::vector<epee::wipeable_string> words_store;
 
       uint32_t word_list_length = word_list.size();
       // 4 bytes -> 3 words.  8 digits base 16 -> 3 digits base 1626
-      for (unsigned int i=0; i < len/4; i++, words += ' ')
+      for (unsigned int i=0; i < len/4; i++, words.push_back(' '))
       {
-        uint32_t w1, w2, w3;
-        
-        uint32_t val;
+        uint32_t w[4];
 
-        memcpy(&val, src + (i * 4), 4);
+        memcpy(&w[0], src + (i * 4), 4);
 
-        w1 = val % word_list_length;
-        w2 = ((val / word_list_length) + w1) % word_list_length;
-        w3 = (((val / word_list_length) / word_list_length) + w2) % word_list_length;
+        w[1] = w[0] % word_list_length;
+        w[2] = ((w[0] / word_list_length) + w[1]) % word_list_length;
+        w[3] = (((w[0] / word_list_length) / word_list_length) + w[2]) % word_list_length;
 
-        words += word_list[w1];
+        words += word_list[w[1]];
         words += ' ';
-        words += word_list[w2];
+        words += word_list[w[2]];
         words += ' ';
-        words += word_list[w3];
+        words += word_list[w[3]];
 
-        words_store.push_back(word_list[w1]);
-        words_store.push_back(word_list[w2]);
-        words_store.push_back(word_list[w3]);
+        words_store.push_back(word_list[w[1]]);
+        words_store.push_back(word_list[w[2]]);
+        words_store.push_back(word_list[w[3]]);
+
+        memwipe(w, sizeof(w));
       }
 
-      words.pop_back();
-      words += (' ' + words_store[create_checksum_index(words_store, language->get_unique_prefix_length())]);
+      words += words_store[create_checksum_index(words_store, language->get_unique_prefix_length())];
       return true;
     }
 
-    bool bytes_to_words(const crypto::secret_key& src, std::string& words,
+    bool bytes_to_words(const crypto::secret_key& src, epee::wipeable_string& words,
       const std::string &language_name)
     {
       return bytes_to_words(src.data, sizeof(src), words, language_name);
@@ -473,11 +478,10 @@ namespace crypto
      * \param  seed The seed to check (a space delimited concatenated word list)
      * \return      true if the seed passed is a old style seed false if not.
      */
-    bool get_is_old_style_seed(std::string seed)
+    bool get_is_old_style_seed(const epee::wipeable_string &seed)
     {
-      std::vector<std::string> word_list;
-      boost::algorithm::trim(seed);
-      boost::split(word_list, seed, boost::is_any_of(" "), boost::token_compress_on);
+      std::vector<epee::wipeable_string> word_list;
+      seed.split(word_list);
       return word_list.size() != (seed_length + 1);
     }
 

--- a/src/mnemonics/electrum-words.h
+++ b/src/mnemonics/electrum-words.h
@@ -44,6 +44,8 @@
 #include <map>
 #include "crypto/crypto.h"  // for declaration of crypto::secret_key
 
+namespace epee {  class wipeable_string; }
+
 /*!
  * \namespace crypto
  * 
@@ -70,7 +72,7 @@ namespace crypto
      * \param  language_name   Language of the seed as found gets written here.
      * \return                 false if not a multiple of 3 words, or if word is not in the words list
      */
-    bool words_to_bytes(std::string words, std::string& dst, size_t len, bool duplicate,
+    bool words_to_bytes(const epee::wipeable_string &words, epee::wipeable_string& dst, size_t len, bool duplicate,
       std::string &language_name);
     /*!
      * \brief Converts seed words to bytes (secret key).
@@ -79,7 +81,7 @@ namespace crypto
      * \param  language_name   Language of the seed as found gets written here.
      * \return                 false if not a multiple of 3 words, or if word is not in the words list
      */
-    bool words_to_bytes(std::string words, crypto::secret_key& dst,
+    bool words_to_bytes(const epee::wipeable_string &words, crypto::secret_key& dst,
       std::string &language_name);
 
     /*!
@@ -90,7 +92,7 @@ namespace crypto
      * \param  language_name Seed language name
      * \return               true if successful false if not. Unsuccessful if wrong key size.
      */
-    bool bytes_to_words(const char *src, size_t len, std::string& words,
+    bool bytes_to_words(const char *src, size_t len, epee::wipeable_string& words,
       const std::string &language_name);
 
     /*!
@@ -100,7 +102,7 @@ namespace crypto
      * \param  language_name Seed language name
      * \return               true if successful false if not. Unsuccessful if wrong key size.
      */
-    bool bytes_to_words(const crypto::secret_key& src, std::string& words,
+    bool bytes_to_words(const crypto::secret_key& src, epee::wipeable_string& words,
       const std::string &language_name);
 
     /*!
@@ -115,7 +117,7 @@ namespace crypto
      * \param  seed The seed to check (a space delimited concatenated word list)
      * \return      true if the seed passed is a old style seed false if not.
      */
-    bool get_is_old_style_seed(std::string seed);
+    bool get_is_old_style_seed(const epee::wipeable_string &seed);
 
     /*!
      * \brief Returns the name of a language in English

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -932,7 +932,7 @@ namespace nodetool
     bool res = m_net_server.connect(epee::string_tools::get_ip_string_from_int32(ipv4.ip()),
       epee::string_tools::num_to_string_fast(ipv4.port()),
       m_config.m_net_config.connection_timeout,
-      con);
+      con, m_bind_ip.empty() ? "0.0.0.0" : m_bind_ip);
 
     if(!res)
     {
@@ -997,7 +997,7 @@ namespace nodetool
     bool res = m_net_server.connect(epee::string_tools::get_ip_string_from_int32(ipv4.ip()),
                                     epee::string_tools::num_to_string_fast(ipv4.port()),
                                     m_config.m_net_config.connection_timeout,
-                                    con);
+                                    con, m_bind_ip.empty() ? "0.0.0.0" : m_bind_ip);
 
     if (!res) {
       bool is_priority = is_priority_node(na);
@@ -1619,7 +1619,7 @@ namespace nodetool
         return false;
       }
       return true;
-    });
+    }, m_bind_ip.empty() ? "0.0.0.0" : m_bind_ip);
     if(!r)
     {
       LOG_WARNING_CC(context, "Failed to call connect_async, network error.");

--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -404,6 +404,16 @@ namespace rct {
     };
     struct rctSig: public rctSigBase {
         rctSigPrunable p;
+
+        keyV& get_pseudo_outs()
+        {
+          return type == RCTTypeSimpleBulletproof ? p.pseudoOuts : pseudoOuts;
+        }
+
+        keyV const& get_pseudo_outs() const
+        {
+          return type == RCTTypeSimpleBulletproof ? p.pseudoOuts : pseudoOuts;
+        }
     };
 
     //other basepoint H = toPoint(cn_fast_hash(G)), G the basepoint

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -86,11 +86,27 @@ namespace rpc
           res.error_details = "incorrect number of transactions retrieved for block";
           return;
       }
-      std::vector<transaction> txs;
-      for (const auto& p : it->second)
+
+      cryptonote::rpc::block_output_indices& indices = res.output_indices[block_count];
+
+      // miner tx output indices
       {
-        txs.resize(txs.size() + 1);
-        if (!parse_and_validate_tx_from_blob(p.second, txs.back()))
+        cryptonote::rpc::tx_output_indices tx_indices;
+        if (!m_core.get_tx_outputs_gindexs(get_transaction_hash(bwt.block.miner_tx), tx_indices))
+        {
+          res.status = Message::STATUS_FAILED;
+          res.error_details = "core::get_tx_outputs_gindexs() returned false";
+          return;
+        }
+        indices.push_back(std::move(tx_indices));
+      }
+
+      auto hash_it = bwt.block.tx_hashes.begin();
+      bwt.transactions.reserve(it->second.size());
+      for (const auto& blob : it->second)
+      {
+        bwt.transactions.emplace_back();
+        if (!parse_and_validate_tx_from_blob(blob.second, bwt.transactions.back()))
         {
           res.blocks.clear();
           res.output_indices.clear();
@@ -98,41 +114,17 @@ namespace rpc
           res.error_details = "failed retrieving a requested transaction";
           return;
         }
-      }
-
-      cryptonote::rpc::block_output_indices& indices = res.output_indices[block_count];
-
-      // miner tx output indices
-      {
-        cryptonote::rpc::tx_output_indices tx_indices;
-        bool r = m_core.get_tx_outputs_gindexs(get_transaction_hash(bwt.block.miner_tx), tx_indices);
-        if (!r)
-        {
-          res.status = Message::STATUS_FAILED;
-          res.error_details = "core::get_tx_outputs_gindexs() returned false";
-          return;
-        }
-        indices.push_back(tx_indices);
-      }
-
-      // assume each block returned is returned with all its transactions
-      // in the correct order.
-      auto tx_it = txs.begin();
-      for (const crypto::hash& h : bwt.block.tx_hashes)
-      {
-        bwt.transactions.emplace(h, *tx_it);
-        tx_it++;
 
         cryptonote::rpc::tx_output_indices tx_indices;
-        bool r = m_core.get_tx_outputs_gindexs(h, tx_indices);
-        if (!r)
+        if (!m_core.get_tx_outputs_gindexs(*hash_it, tx_indices))
         {
           res.status = Message::STATUS_FAILED;
           res.error_details = "core::get_tx_outputs_gindexs() returned false";
           return;
         }
 
-        indices.push_back(tx_indices);
+        indices.push_back(std::move(tx_indices));
+        ++hash_it;
       }
 
       it++;

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -44,7 +44,7 @@ namespace rpc
   struct block_with_transactions
   {
     cryptonote::block block;
-    std::unordered_map<crypto::hash, cryptonote::transaction> transactions;
+    std::vector<cryptonote::transaction> transactions;
   };
 
   typedef std::vector<uint64_t> tx_output_indices;

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -28,6 +28,8 @@
 
 #include "json_object.h"
 
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/variant/apply_visitor.hpp>
 #include <limits>
 #include <type_traits>
 #include "string_tools.h"
@@ -219,11 +221,11 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::transaction& tx, ra
 
   INSERT_INTO_JSON_OBJECT(val, doc, version, tx.version);
   INSERT_INTO_JSON_OBJECT(val, doc, unlock_time, tx.unlock_time);
-  INSERT_INTO_JSON_OBJECT(val, doc, vin, tx.vin);
-  INSERT_INTO_JSON_OBJECT(val, doc, vout, tx.vout);
+  INSERT_INTO_JSON_OBJECT(val, doc, inputs, tx.vin);
+  INSERT_INTO_JSON_OBJECT(val, doc, outputs, tx.vout);
   INSERT_INTO_JSON_OBJECT(val, doc, extra, tx.extra);
   INSERT_INTO_JSON_OBJECT(val, doc, signatures, tx.signatures);
-  INSERT_INTO_JSON_OBJECT(val, doc, rct_signatures, tx.rct_signatures);
+  INSERT_INTO_JSON_OBJECT(val, doc, ringct, tx.rct_signatures);
 }
 
 
@@ -236,11 +238,11 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::transaction& tx)
 
   GET_FROM_JSON_OBJECT(val, tx.version, version);
   GET_FROM_JSON_OBJECT(val, tx.unlock_time, unlock_time);
-  GET_FROM_JSON_OBJECT(val, tx.vin, vin);
-  GET_FROM_JSON_OBJECT(val, tx.vout, vout);
+  GET_FROM_JSON_OBJECT(val, tx.vin, inputs);
+  GET_FROM_JSON_OBJECT(val, tx.vout, outputs);
   GET_FROM_JSON_OBJECT(val, tx.extra, extra);
   GET_FROM_JSON_OBJECT(val, tx.signatures, signatures);
-  GET_FROM_JSON_OBJECT(val, tx.rct_signatures, rct_signatures);
+  GET_FROM_JSON_OBJECT(val, tx.rct_signatures, ringct);
 }
 
 void toJsonValue(rapidjson::Document& doc, const cryptonote::block& b, rapidjson::Value& val)
@@ -277,26 +279,31 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::txin_v& txin, rapid
 {
   val.SetObject();
 
-  if (txin.type() == typeid(cryptonote::txin_gen))
+  struct add_input
   {
-    val.AddMember("type", "txin_gen", doc.GetAllocator());
-    INSERT_INTO_JSON_OBJECT(val, doc, value, boost::get<cryptonote::txin_gen>(txin));
-  }
-  else if (txin.type() == typeid(cryptonote::txin_to_script))
-  {
-    val.AddMember("type", "txin_to_script", doc.GetAllocator());
-    INSERT_INTO_JSON_OBJECT(val, doc, value, boost::get<cryptonote::txin_to_script>(txin));
-  }
-  else if (txin.type() == typeid(cryptonote::txin_to_scripthash))
-  {
-    val.AddMember("type", "txin_to_scripthash", doc.GetAllocator());
-    INSERT_INTO_JSON_OBJECT(val, doc, value, boost::get<cryptonote::txin_to_scripthash>(txin));
-  }
-  else if (txin.type() == typeid(cryptonote::txin_to_key))
-  {
-    val.AddMember("type", "txin_to_key", doc.GetAllocator());
-    INSERT_INTO_JSON_OBJECT(val, doc, value, boost::get<cryptonote::txin_to_key>(txin));
-  }
+    using result_type = void;
+
+    rapidjson::Document& doc;
+    rapidjson::Value& val;
+
+    void operator()(cryptonote::txin_to_key const& input) const
+    {
+      INSERT_INTO_JSON_OBJECT(val, doc, to_key, input);
+    }
+    void operator()(cryptonote::txin_gen const& input) const
+    {
+      INSERT_INTO_JSON_OBJECT(val, doc, gen, input);
+    }
+    void operator()(cryptonote::txin_to_script const& input) const
+    {
+      INSERT_INTO_JSON_OBJECT(val, doc, to_script, input);
+    }
+    void operator()(cryptonote::txin_to_scripthash const& input) const
+    {
+      INSERT_INTO_JSON_OBJECT(val, doc, to_scripthash, input);
+    }
+  };
+  boost::apply_visitor(add_input{doc, val}, txin);
 }
 
 
@@ -307,31 +314,37 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_v& txin)
     throw WRONG_TYPE("json object");
   }
 
-  OBJECT_HAS_MEMBER_OR_THROW(val, "type")
-  OBJECT_HAS_MEMBER_OR_THROW(val, "value")
-  if (val["type"]== "txin_gen")
+  if (val.MemberCount() != 1)
   {
-    cryptonote::txin_gen tmpVal;
-    fromJsonValue(val["value"], tmpVal);
-    txin = tmpVal;
+    throw MISSING_KEY("Invalid input object");
   }
-  else if (val["type"]== "txin_to_script")
+
+  for (auto const& elem : val.GetObject())
   {
-    cryptonote::txin_to_script tmpVal;
-    fromJsonValue(val["value"], tmpVal);
-    txin = tmpVal;
-  }
-  else if (val["type"] == "txin_to_scripthash")
-  {
-    cryptonote::txin_to_scripthash tmpVal;
-    fromJsonValue(val["value"], tmpVal);
-    txin = tmpVal;
-  }
-  else if (val["type"] == "txin_to_key")
-  {
-    cryptonote::txin_to_key tmpVal;
-    fromJsonValue(val["value"], tmpVal);
-    txin = tmpVal;
+    if (elem.name == "to_key")
+    {
+      cryptonote::txin_to_key tmpVal;
+      fromJsonValue(elem.value, tmpVal);
+      txin = std::move(tmpVal);
+    }
+    else if (elem.name == "gen")
+    {
+      cryptonote::txin_gen tmpVal;
+      fromJsonValue(elem.value, tmpVal);
+      txin = std::move(tmpVal);
+    }
+    else if (elem.name == "to_script")
+    {
+      cryptonote::txin_to_script tmpVal;
+      fromJsonValue(elem.value, tmpVal);
+      txin = std::move(tmpVal);
+    }
+    else if (elem.name == "to_scripthash")
+    {
+      cryptonote::txin_to_scripthash tmpVal;
+      fromJsonValue(elem.value, tmpVal);
+      txin = std::move(tmpVal);
+    }
   }
 }
 
@@ -405,7 +418,7 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::txin_to_key& txin, 
 
   INSERT_INTO_JSON_OBJECT(val, doc, amount, txin.amount);
   INSERT_INTO_JSON_OBJECT(val, doc, key_offsets, txin.key_offsets);
-  INSERT_INTO_JSON_OBJECT(val, doc, k_image, txin.k_image);
+  INSERT_INTO_JSON_OBJECT(val, doc, key_image, txin.k_image);
 }
 
 
@@ -418,58 +431,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin)
 
   GET_FROM_JSON_OBJECT(val, txin.amount, amount);
   GET_FROM_JSON_OBJECT(val, txin.key_offsets, key_offsets);
-  GET_FROM_JSON_OBJECT(val, txin.k_image, k_image);
-}
-
-void toJsonValue(rapidjson::Document& doc, const cryptonote::txout_target_v& txout, rapidjson::Value& val)
-{
-  val.SetObject();
-
-  if (txout.type() == typeid(cryptonote::txout_to_script))
-  {
-    val.AddMember("type", "txout_to_script", doc.GetAllocator());
-    INSERT_INTO_JSON_OBJECT(val, doc, value, boost::get<cryptonote::txout_to_script>(txout));
-  }
-  else if (txout.type() == typeid(cryptonote::txout_to_scripthash))
-  {
-    val.AddMember("type", "txout_to_scripthash", doc.GetAllocator());
-    INSERT_INTO_JSON_OBJECT(val, doc, value, boost::get<cryptonote::txout_to_scripthash>(txout));
-  }
-  else if (txout.type() == typeid(cryptonote::txout_to_key))
-  {
-    val.AddMember("type", "txout_to_key", doc.GetAllocator());
-    INSERT_INTO_JSON_OBJECT(val, doc, value, boost::get<cryptonote::txout_to_key>(txout));
-  }
-}
-
-
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_target_v& txout)
-{
-  if (!val.IsObject())
-  {
-    throw WRONG_TYPE("json object");
-  }
-
-  OBJECT_HAS_MEMBER_OR_THROW(val, "type")
-  OBJECT_HAS_MEMBER_OR_THROW(val, "value")
-  if (val["type"]== "txout_to_script")
-  {
-    cryptonote::txout_to_script tmpVal;
-    fromJsonValue(val["value"], tmpVal);
-    txout = tmpVal;
-  }
-  else if (val["type"] == "txout_to_scripthash")
-  {
-    cryptonote::txout_to_scripthash tmpVal;
-    fromJsonValue(val["value"], tmpVal);
-    txout = tmpVal;
-  }
-  else if (val["type"] == "txout_to_key")
-  {
-    cryptonote::txout_to_key tmpVal;
-    fromJsonValue(val["value"], tmpVal);
-    txout = tmpVal;
-  }
+  GET_FROM_JSON_OBJECT(val, txin.k_image, key_image);
 }
 
 void toJsonValue(rapidjson::Document& doc, const cryptonote::txout_to_script& txout, rapidjson::Value& val)
@@ -533,7 +495,28 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::tx_out& txout, rapi
   val.SetObject();
 
   INSERT_INTO_JSON_OBJECT(val, doc, amount, txout.amount);
-  INSERT_INTO_JSON_OBJECT(val, doc, target, txout.target);
+
+  struct add_output
+  {
+    using result_type = void;
+
+    rapidjson::Document& doc;
+    rapidjson::Value& val;
+
+    void operator()(cryptonote::txout_to_key const& output) const
+    {
+      INSERT_INTO_JSON_OBJECT(val, doc, to_key, output);
+    }
+    void operator()(cryptonote::txout_to_script const& output) const
+    {
+      INSERT_INTO_JSON_OBJECT(val, doc, to_script, output);
+    }
+    void operator()(cryptonote::txout_to_scripthash const& output) const
+    {
+      INSERT_INTO_JSON_OBJECT(val, doc, to_scripthash, output);
+    }
+  };
+  boost::apply_visitor(add_output{doc, val}, txout.target);
 }
 
 void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_out& txout)
@@ -543,8 +526,37 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_out& txout)
     throw WRONG_TYPE("json object");
   }
 
-  GET_FROM_JSON_OBJECT(val, txout.amount, amount);
-  GET_FROM_JSON_OBJECT(val, txout.target, target);
+  if (val.MemberCount() != 2)
+  {
+    throw MISSING_KEY("Invalid input object");
+  }
+
+  for (auto const& elem : val.GetObject())
+  {
+    if (elem.name == "amount")
+    {
+      fromJsonValue(elem.value, txout.amount);
+    }
+
+    if (elem.name == "to_key")
+    {
+      cryptonote::txout_to_key tmpVal;
+      fromJsonValue(elem.value, tmpVal);
+      txout.target = std::move(tmpVal);
+    }
+    else if (elem.name == "to_script")
+    {
+      cryptonote::txout_to_script tmpVal;
+      fromJsonValue(elem.value, tmpVal);
+      txout.target = std::move(tmpVal);
+    }
+    else if (elem.name == "to_scripthash")
+    {
+      cryptonote::txout_to_scripthash tmpVal;
+      fromJsonValue(elem.value, tmpVal);
+      txout.target = std::move(tmpVal);
+    }
+  }
 }
 
 void toJsonValue(rapidjson::Document& doc, const cryptonote::connection_info& info, rapidjson::Value& val)
@@ -617,7 +629,7 @@ void toJsonValue(rapidjson::Document& doc, const cryptonote::block_complete_entr
   val.SetObject();
 
   INSERT_INTO_JSON_OBJECT(val, doc, block, blk.block);
-  INSERT_INTO_JSON_OBJECT(val, doc, txs, blk.txs);
+  INSERT_INTO_JSON_OBJECT(val, doc, transactions, blk.txs);
 }
 
 
@@ -629,7 +641,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::block_complete_entry
   }
 
   GET_FROM_JSON_OBJECT(val, blk.block, block);
-  GET_FROM_JSON_OBJECT(val, blk.txs, txs);
+  GET_FROM_JSON_OBJECT(val, blk.txs, transactions);
 }
 
 void toJsonValue(rapidjson::Document& doc, const cryptonote::rpc::block_with_transactions& blk, rapidjson::Value& val)
@@ -936,51 +948,70 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResp
 
 void toJsonValue(rapidjson::Document& doc, const rct::rctSig& sig, rapidjson::Value& val)
 {
+  using boost::adaptors::transform;
+
   val.SetObject();
 
+  const auto just_mask = [] (rct::ctkey const& key) -> rct::key const&
+  {
+    return key.mask;
+  };
+
   INSERT_INTO_JSON_OBJECT(val, doc, type, sig.type);
-  INSERT_INTO_JSON_OBJECT(val, doc, message, sig.message);
-  INSERT_INTO_JSON_OBJECT(val, doc, mixRing, sig.mixRing);
-  INSERT_INTO_JSON_OBJECT(val, doc, pseudoOuts, sig.pseudoOuts);
-  INSERT_INTO_JSON_OBJECT(val, doc, ecdhInfo, sig.ecdhInfo);
-  INSERT_INTO_JSON_OBJECT(val, doc, outPk, sig.outPk);
-  INSERT_INTO_JSON_OBJECT(val, doc, txnFee, sig.txnFee);
-  INSERT_INTO_JSON_OBJECT(val, doc, p, sig.p);
+  INSERT_INTO_JSON_OBJECT(val, doc, encrypted, sig.ecdhInfo);
+  INSERT_INTO_JSON_OBJECT(val, doc, commitments, transform(sig.outPk, just_mask));
+  INSERT_INTO_JSON_OBJECT(val, doc, fee, sig.txnFee);
+
+  // prunable
+  {
+    rapidjson::Value prunable;
+    prunable.SetObject();
+
+    INSERT_INTO_JSON_OBJECT(prunable, doc, range_proofs, sig.p.rangeSigs);
+    INSERT_INTO_JSON_OBJECT(prunable, doc, bulletproofs, sig.p.bulletproofs);
+    INSERT_INTO_JSON_OBJECT(prunable, doc, mlsags, sig.p.MGs);
+    INSERT_INTO_JSON_OBJECT(prunable, doc, pseudo_outs, sig.get_pseudo_outs());
+
+    val.AddMember("prunable", prunable, doc.GetAllocator());
+  }
 }
 
 void fromJsonValue(const rapidjson::Value& val, rct::rctSig& sig)
 {
+  using boost::adaptors::transform;
+
   if (!val.IsObject())
   {
     throw WRONG_TYPE("json object");
   }
+
+  std::vector<rct::key> commitments;
 
   GET_FROM_JSON_OBJECT(val, sig.type, type);
-  GET_FROM_JSON_OBJECT(val, sig.message, message);
-  GET_FROM_JSON_OBJECT(val, sig.mixRing, mixRing);
-  GET_FROM_JSON_OBJECT(val, sig.pseudoOuts, pseudoOuts);
-  GET_FROM_JSON_OBJECT(val, sig.ecdhInfo, ecdhInfo);
-  GET_FROM_JSON_OBJECT(val, sig.outPk, outPk);
-  GET_FROM_JSON_OBJECT(val, sig.txnFee, txnFee);
-  GET_FROM_JSON_OBJECT(val, sig.p, p);
-}
+  GET_FROM_JSON_OBJECT(val, sig.ecdhInfo, encrypted);
+  GET_FROM_JSON_OBJECT(val, commitments, commitments);
+  GET_FROM_JSON_OBJECT(val, sig.txnFee, fee);
 
-void toJsonValue(rapidjson::Document& doc, const rct::ctkey& key, rapidjson::Value& val)
-{
-  val.SetObject();
-
-  INSERT_INTO_JSON_OBJECT(val, doc, dest, key.dest);
-  INSERT_INTO_JSON_OBJECT(val, doc, mask, key.mask);
-}
-
-void fromJsonValue(const rapidjson::Value& val, rct::ctkey& key)
-{
-  if (!val.IsObject())
+  // prunable
   {
-    throw WRONG_TYPE("json object");
+    OBJECT_HAS_MEMBER_OR_THROW(val, "prunable");
+    const auto& prunable = val["prunable"];
+
+    rct::keyV pseudo_outs;
+
+    GET_FROM_JSON_OBJECT(prunable, sig.p.rangeSigs, range_proofs);
+    GET_FROM_JSON_OBJECT(prunable, sig.p.bulletproofs, bulletproofs);
+    GET_FROM_JSON_OBJECT(prunable, sig.p.MGs, mlsags);
+    GET_FROM_JSON_OBJECT(prunable, pseudo_outs, pseudo_outs);
+
+    sig.get_pseudo_outs() = std::move(pseudo_outs);
   }
-  GET_FROM_JSON_OBJECT(val, key.dest, dest);
-  GET_FROM_JSON_OBJECT(val, key.mask, mask);
+
+  sig.outPk.reserve(commitments.size());
+  for (rct::key const& commitment : commitments)
+  {
+    sig.outPk.push_back({{}, commitment});
+  }
 }
 
 void toJsonValue(rapidjson::Document& doc, const rct::ecdhTuple& tuple, rapidjson::Value& val)
@@ -1002,27 +1033,6 @@ void fromJsonValue(const rapidjson::Value& val, rct::ecdhTuple& tuple)
   GET_FROM_JSON_OBJECT(val, tuple.amount, amount);
 }
 
-void toJsonValue(rapidjson::Document& doc, const rct::rctSigPrunable& sig, rapidjson::Value& val)
-{
-  val.SetObject();
-
-  INSERT_INTO_JSON_OBJECT(val, doc, rangeSigs, sig.rangeSigs);
-  INSERT_INTO_JSON_OBJECT(val, doc, bulletproofs, sig.bulletproofs);
-  INSERT_INTO_JSON_OBJECT(val, doc, MGs, sig.MGs);
-}
-
-void fromJsonValue(const rapidjson::Value& val, rct::rctSigPrunable& sig)
-{
-  if (!val.IsObject())
-  {
-    throw WRONG_TYPE("json object");
-  }
-
-  GET_FROM_JSON_OBJECT(val, sig.rangeSigs, rangeSigs);
-  GET_FROM_JSON_OBJECT(val, sig.bulletproofs, bulletproofs);
-  GET_FROM_JSON_OBJECT(val, sig.MGs, MGs);
-}
-
 void toJsonValue(rapidjson::Document& doc, const rct::rangeSig& sig, rapidjson::Value& val)
 {
   val.SetObject();
@@ -1040,10 +1050,16 @@ void fromJsonValue(const rapidjson::Value& val, rct::rangeSig& sig)
     throw WRONG_TYPE("json object");
   }
 
+  const auto ci = val.FindMember("Ci");
+  if (ci == val.MemberEnd())
+  {
+    throw MISSING_KEY("Ci");
+  }
+
   GET_FROM_JSON_OBJECT(val, sig.asig, asig);
 
   std::vector<rct::key> keyVector;
-  cryptonote::json::fromJsonValue(val["Ci"], keyVector);
+  cryptonote::json::fromJsonValue(ci->value, keyVector);
   if (!(keyVector.size() == 64))
   {
     throw WRONG_TYPE("key64 (rct::key[64])");
@@ -1098,10 +1114,10 @@ void toJsonValue(rapidjson::Document& doc, const rct::boroSig& sig, rapidjson::V
   val.SetObject();
 
   std::vector<rct::key> keyVector(sig.s0, std::end(sig.s0));
-  INSERT_INTO_JSON_OBJECT(val, doc, s0, sig.s0);
+  INSERT_INTO_JSON_OBJECT(val, doc, s0, keyVector);
 
   keyVector.assign(sig.s1, std::end(sig.s1));
-  INSERT_INTO_JSON_OBJECT(val, doc, s1, sig.s1);
+  INSERT_INTO_JSON_OBJECT(val, doc, s1, keyVector);
 
   INSERT_INTO_JSON_OBJECT(val, doc, ee, sig.ee);
 }

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -263,14 +263,8 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::BlockHeaderResp
 void toJsonValue(rapidjson::Document& doc, const rct::rctSig& i, rapidjson::Value& val);
 void fromJsonValue(const rapidjson::Value& i, rct::rctSig& sig);
 
-void toJsonValue(rapidjson::Document& doc, const rct::ctkey& key, rapidjson::Value& val);
-void fromJsonValue(const rapidjson::Value& val, rct::ctkey& key);
-
 void toJsonValue(rapidjson::Document& doc, const rct::ecdhTuple& tuple, rapidjson::Value& val);
 void fromJsonValue(const rapidjson::Value& val, rct::ecdhTuple& tuple);
-
-void toJsonValue(rapidjson::Document& doc, const rct::rctSigPrunable& sig, rapidjson::Value& val);
-void fromJsonValue(const rapidjson::Value& val, rct::rctSigPrunable& sig);
 
 void toJsonValue(rapidjson::Document& doc, const rct::rangeSig& sig, rapidjson::Value& val);
 void fromJsonValue(const rapidjson::Value& val, rct::rangeSig& sig);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -626,7 +626,7 @@ bool simple_wallet::print_seed(bool encrypted)
   epee::wipeable_string seed_pass;
   if (encrypted)
   {
-    auto pwd_container = password_prompter(tr("Enter optional seed encryption passphrase, empty to see raw seed"), true);
+    auto pwd_container = password_prompter(tr("Enter optional seed offset passphrase, empty to see raw seed"), true);
     if (std::cin.eof() || !pwd_container)
       return true;
     seed_pass = pwd_container->password();
@@ -2796,7 +2796,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         }
       }
 
-      auto pwd_container = password_prompter(tr("Enter seed encryption passphrase, empty if none"), false);
+      auto pwd_container = password_prompter(tr("Enter seed offset passphrase, empty if none"), false);
       if (std::cin.eof() || !pwd_container)
         return false;
       epee::wipeable_string seed_pass = pwd_container->password();

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6485,7 +6485,7 @@ bool simple_wallet::unspent_outputs(const std::vector<std::string> &args_)
   auto local_args = args_;
 
   std::set<uint32_t> subaddr_indices;
-  if (local_args.size() > 0 && local_args[0].substr(0, 6) != "index=")
+  if (local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
   {
     if (!parse_subaddress_indices(local_args[0], subaddr_indices))
       return true;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6492,7 +6492,7 @@ static std::string get_human_readable_timespan(std::chrono::seconds seconds)
   if (ts < 3600 * 24 * 30.5)
     return std::to_string((uint64_t)(ts / (3600 * 24))) + tr(" days");
   if (ts < 3600 * 24 * 365.25)
-    return std::to_string((uint64_t)(ts / (3600 * 24 * 365.25))) + tr(" months");
+    return std::to_string((uint64_t)(ts / (3600 * 24 * 30.5))) + tr(" months");
   return tr("a long time");
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2433,7 +2433,7 @@ simple_wallet::simple_wallet()
                            tr("Show the unspent outputs of a specified address within an optional amount range."));
   m_cmd_binder.set_handler("rescan_bc",
                            boost::bind(&simple_wallet::rescan_blockchain, this, _1),
-                           tr("Rescan the blockchain from scratch."));
+                           tr("Rescan the blockchain from scratch, losing any information which can not be recovered from the blockchain itself."));
   m_cmd_binder.set_handler("set_tx_note",
                            boost::bind(&simple_wallet::set_tx_note, this, _1),
                            tr("set_tx_note <txid> [free text note]"),
@@ -6830,6 +6830,14 @@ bool simple_wallet::unspent_outputs(const std::vector<std::string> &args_)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::rescan_blockchain(const std::vector<std::string> &args_)
 {
+  message_writer() << tr("Warning: this will lose any information which can not be recovered from the blockchain.");
+  message_writer() << tr("This includes destination addresses, tx secret keys, tx notes, etc");
+  std::string confirm = input_line(tr("Rescan anyway ? (Y/Yes/N/No): "));
+  if(!std::cin.eof())
+  {
+    if (!command_line::is_yes(confirm))
+      return true;
+  }
   return refresh_main(0, true);
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -91,13 +91,8 @@ typedef cryptonote::simple_wallet sw;
   m_auto_refresh_enabled.store(false, std::memory_order_relaxed); \
   /* stop any background refresh, and take over */ \
   m_wallet->stop(); \
-  m_idle_mutex.lock(); \
-  while (m_auto_refresh_refreshing) \
-    m_idle_cond.notify_one(); \
-  m_idle_mutex.unlock(); \
-/*  if (auto_refresh_run)*/ \
-    /*m_auto_refresh_thread.join();*/ \
   boost::unique_lock<boost::mutex> lock(m_idle_mutex); \
+  m_idle_cond.notify_all(); \
   epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ \
     m_auto_refresh_enabled.store(auto_refresh_enabled, std::memory_order_relaxed); \
   })

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2333,7 +2333,7 @@ simple_wallet::simple_wallet()
                            tr("Check a signature proving that the owner of <address> holds at least this much, optionally with a challenge string <message>."));
   m_cmd_binder.set_handler("show_transfers",
                            boost::bind(&simple_wallet::show_transfers, this, _1),
-                           tr("show_transfers [in|out|pending|failed|pool] [index=<N1>[,<N2>,...]] [<min_height> [<max_height>]]"),
+                           tr("show_transfers [in|out|pending|failed|pool|coinbase] [index=<N1>[,<N2>,...]] [<min_height> [<max_height>]]"),
                            tr("Show the incoming/outgoing transfers within an optional height range."));
   m_cmd_binder.set_handler("unspent_outputs",
                            boost::bind(&simple_wallet::unspent_outputs, this, _1),
@@ -6290,12 +6290,13 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
   bool pending = true;
   bool failed = true;
   bool pool = true;
+  bool coinbase = true;
   uint64_t min_height = 0;
   uint64_t max_height = (uint64_t)-1;
   boost::optional<uint32_t> subaddr_index;
 
   if(local_args.size() > 4) {
-    fail_msg_writer() << tr("usage: show_transfers [in|out|all|pending|failed] [index=<N1>[,<N2>,...]] [<min_height> [<max_height>]]");
+    fail_msg_writer() << tr("usage: show_transfers [in|out|all|pending|failed|coinbase] [index=<N1>[,<N2>,...]] [<min_height> [<max_height>]]");
     return true;
   }
 
@@ -6308,19 +6309,24 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
       local_args.erase(local_args.begin());
     }
     else if (local_args[0] == "out" || local_args[0] == "outgoing") {
-      in = pool = false;
+      in = pool = coinbase = false;
       local_args.erase(local_args.begin());
     }
     else if (local_args[0] == "pending") {
-      in = out = failed = false;
+      in = out = failed = coinbase = false;
       local_args.erase(local_args.begin());
     }
     else if (local_args[0] == "failed") {
-      in = out = pending = pool = false;
+      in = out = pending = pool = coinbase = false;
       local_args.erase(local_args.begin());
     }
     else if (local_args[0] == "pool") {
-      in = out = pending = failed = false;
+      in = out = pending = failed = coinbase = false;
+      local_args.erase(local_args.begin());
+    }
+    else if (local_args[0] == "coinbase") {
+      in = out = pending = failed = pool = false;
+      coinbase = true;
       local_args.erase(local_args.begin());
     }
     else if (local_args[0] == "all" || local_args[0] == "both") {
@@ -6361,20 +6367,23 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
     local_args.erase(local_args.begin());
   }
 
-  std::multimap<uint64_t, std::pair<bool,std::string>> output;
+  std::multimap<uint64_t, std::tuple<epee::console_colors, std::string, std::string>> output;
 
   PAUSE_READLINE();
 
-  if (in) {
+  if (in || coinbase) {
     std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
     m_wallet->get_payments(payments, min_height, max_height, m_current_subaddress_account, subaddr_indices);
     for (std::list<std::pair<crypto::hash, tools::wallet2::payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
       const tools::wallet2::payment_details &pd = i->second;
+      if (!pd.m_coinbase && !in)
+        continue;
       std::string payment_id = string_tools::pod_to_hex(i->first);
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
       std::string note = m_wallet->get_tx_note(pd.m_tx_hash);
-      output.insert(std::make_pair(pd.m_block_height, std::make_pair(true, (boost::format("%25.25s %20.20s %s %s %d %s %s") % get_human_readable_timestamp(pd.m_timestamp) % print_money(pd.m_amount) % string_tools::pod_to_hex(pd.m_tx_hash) % payment_id % pd.m_subaddr_index.minor % "-" % note).str())));
+      const std::string type = pd.m_coinbase ? tr("block") : tr("in");
+      output.insert(std::make_pair(pd.m_block_height, std::make_tuple(epee::console_color_green, type, (boost::format("%25.25s %20.20s %s %s %d %s %s") % get_human_readable_timestamp(pd.m_timestamp) % print_money(pd.m_amount) % string_tools::pod_to_hex(pd.m_tx_hash) % payment_id % pd.m_subaddr_index.minor % "-" % note).str())));
     }
   }
 
@@ -6407,15 +6416,15 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
       if (payment_id.substr(16).find_first_not_of('0') == std::string::npos)
         payment_id = payment_id.substr(0,16);
       std::string note = m_wallet->get_tx_note(i->first);
-      output.insert(std::make_pair(pd.m_block_height, std::make_pair(false, (boost::format("%25.25s %20.20s %s %s %14.14s %s %s - %s") % get_human_readable_timestamp(pd.m_timestamp) % print_money(pd.m_amount_in - change - fee) % string_tools::pod_to_hex(i->first) % payment_id % print_money(fee) % dests % print_subaddr_indices(pd.m_subaddr_indices) % note).str())));
+      output.insert(std::make_pair(pd.m_block_height, std::make_tuple(epee::console_color_magenta, tr("out"), (boost::format("%25.25s %20.20s %s %s %14.14s %s %s - %s") % get_human_readable_timestamp(pd.m_timestamp) % print_money(pd.m_amount_in - change - fee) % string_tools::pod_to_hex(i->first) % payment_id % print_money(fee) % dests % print_subaddr_indices(pd.m_subaddr_indices) % note).str())));
     }
   }
 
   // print in and out sorted by height
-  for (std::map<uint64_t, std::pair<bool, std::string>>::const_iterator i = output.begin(); i != output.end(); ++i) {
-    message_writer(i->second.first ? console_color_green : console_color_magenta, false) <<
+  for (std::multimap<uint64_t, std::tuple<epee::console_colors, std::string, std::string>>::const_iterator i = output.begin(); i != output.end(); ++i) {
+    message_writer(std::get<0>(i->second), false) <<
       boost::format("%8.8llu %6.6s %s") %
-      ((unsigned long long)i->first) % (i->second.first ? tr("in") : tr("out")) % i->second.second;
+      ((unsigned long long)i->first) % std::get<1>(i->second) % std::get<2>(i->second);
   }
 
   if (pool) {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3353,14 +3353,16 @@ bool simple_wallet::try_connect_to_daemon(bool silent, uint32_t* version)
  */
 std::string simple_wallet::get_mnemonic_language()
 {
-  std::vector<std::string> language_list;
+  std::vector<std::string> language_list_self, language_list_english;
+  const std::vector<std::string> &language_list = m_use_english_language_names ? language_list_english : language_list_self;
   std::string language_choice;
   int language_number = -1;
-  crypto::ElectrumWords::get_language_list(language_list, m_use_english_language_names);
+  crypto::ElectrumWords::get_language_list(language_list_self, false);
+  crypto::ElectrumWords::get_language_list(language_list_english, true);
   std::cout << tr("List of available languages for your wallet's seed:") << std::endl;
   std::cout << tr("If your display freezes, exit blind with ^C, then run again with --use-english-language-names") << std::endl;
   int ii;
-  std::vector<std::string>::iterator it;
+  std::vector<std::string>::const_iterator it;
   for (it = language_list.begin(), ii = 0; it != language_list.end(); it++, ii++)
   {
     std::cout << ii << " : " << *it << std::endl;
@@ -3384,7 +3386,7 @@ std::string simple_wallet::get_mnemonic_language()
       fail_msg_writer() << tr("invalid language choice entered. Please try again.\n");
     }
   }
-  return language_list[language_number];
+  return language_list_self[language_number];
 }
 //----------------------------------------------------------------------------------------------------
 boost::optional<tools::password_container> simple_wallet::get_and_verify_password() const

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -102,6 +102,12 @@ typedef cryptonote::simple_wallet sw;
     m_auto_refresh_enabled.store(auto_refresh_enabled, std::memory_order_relaxed); \
   })
 
+#define SCOPED_WALLET_UNLOCK() \
+  LOCK_IDLE_SCOPE(); \
+  boost::optional<tools::password_container> pwd_container = boost::none; \
+  if (m_wallet->ask_password() && !m_wallet->watch_only() && !(pwd_container = get_and_verify_password())) { return true; } \
+  tools::wallet_keys_unlocker unlocker(*m_wallet, pwd_container);
+
 enum TransferType {
   TransferOriginal,
   TransferNew,
@@ -551,6 +557,18 @@ namespace
     }
     return true;
   }
+
+  void print_secret_key(const crypto::secret_key &k)
+  {
+    static constexpr const char hex[] = u8"0123456789abcdef";
+    const uint8_t *ptr = (const uint8_t*)k.data;
+    for (size_t i = 0, sz = sizeof(k); i < sz; ++i)
+    {
+      putchar(hex[*ptr >> 4]);
+      putchar(hex[*ptr & 15]);
+      ++ptr;
+    }
+  }
 }
 
 bool parse_priority(const std::string& arg, uint32_t& priority)
@@ -600,12 +618,15 @@ std::string simple_wallet::get_command_usage(const std::vector<std::string> &arg
 
 bool simple_wallet::viewkey(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+  SCOPED_WALLET_UNLOCK();
   // don't log
+  PAUSE_READLINE();
   if (m_wallet->key_on_device()) {
     std::cout << "secret: On device. Not available" << std::endl;
   } else {
-    std::cout << "secret: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key) << std::endl;
+    printf("secret: ");
+    print_secret_key(m_wallet->get_account().get_keys().m_view_secret_key);
+    putchar('\n');
   }
   std::cout << "public: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_account_address.m_view_public_key) << std::endl;
 
@@ -619,12 +640,15 @@ bool simple_wallet::spendkey(const std::vector<std::string> &args/* = std::vecto
     fail_msg_writer() << tr("wallet is watch-only and has no spend key");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+  SCOPED_WALLET_UNLOCK();
   // don't log
+  PAUSE_READLINE();
   if (m_wallet->key_on_device()) {
     std::cout << "secret: On device. Not available" << std::endl;
   } else {
-    std::cout << "secret: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_spend_secret_key) << std::endl;
+    printf("secret: ");
+    print_secret_key(m_wallet->get_account().get_keys().m_spend_secret_key);
+    putchar('\n');
   }
   std::cout << "public: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_account_address.m_spend_public_key) << std::endl;
 
@@ -647,7 +671,8 @@ bool simple_wallet::print_seed(bool encrypted)
     fail_msg_writer() << tr("wallet is watch-only and has no seed");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
 
   multisig = m_wallet->multisig(&ready);
   if (multisig)
@@ -716,22 +741,36 @@ bool simple_wallet::seed_set_language(const std::vector<std::string> &args/* = s
     fail_msg_writer() << tr("wallet is watch-only and has no seed");
     return true;
   }
-  if (!m_wallet->is_deterministic())
-  {
-    fail_msg_writer() << tr("wallet is non-deterministic and has no seed");
-    return true;
-  }
- 
-  const auto pwd_container = get_and_verify_password();
-  if (pwd_container)
-  {
-    std::string mnemonic_language = get_mnemonic_language();
-    if (mnemonic_language.empty())
-      return true;
 
-    m_wallet->set_seed_language(std::move(mnemonic_language));
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
+  epee::wipeable_string password;
+  {
+    SCOPED_WALLET_UNLOCK();
+
+    if (!m_wallet->is_deterministic())
+    {
+      fail_msg_writer() << tr("wallet is non-deterministic and has no seed");
+      return true;
+    }
+
+    // we need the password, even if ask-password is unset
+    if (!pwd_container)
+    {
+      pwd_container = get_and_verify_password();
+      if (pwd_container == boost::none)
+      {
+        fail_msg_writer() << tr("Incorrect password");
+        return true;
+      }
+    }
+    password = pwd_container->password();
   }
+
+  std::string mnemonic_language = get_mnemonic_language();
+  if (mnemonic_language.empty())
+    return true;
+
+  m_wallet->set_seed_language(std::move(mnemonic_language));
+  m_wallet->rewrite(m_wallet_file, password);
   return true;
 }
 
@@ -752,8 +791,7 @@ bool simple_wallet::change_password(const std::vector<std::string> &args)
 
   try
   {
-    m_wallet->rewrite(m_wallet_file, pwd_container->password());
-    m_wallet->store();
+    m_wallet->change_password(m_wallet_file, orig_pwd_container->password(), pwd_container->password());
   }
   catch (const tools::error::wallet_logic_error& e)
   {
@@ -856,12 +894,7 @@ bool simple_wallet::prepare_multisig(const std::vector<std::string> &args)
     return true;
   }
 
-  const auto orig_pwd_container = get_and_verify_password();
-  if(orig_pwd_container == boost::none)
-  {
-    fail_msg_writer() << tr("Your password is incorrect.");
-    return true;
-  }
+  SCOPED_WALLET_UNLOCK();
 
   std::string multisig_info = m_wallet->get_multisig_info();
   success_msg_writer() << multisig_info;
@@ -894,13 +927,6 @@ bool simple_wallet::make_multisig(const std::vector<std::string> &args)
     return true;
   }
 
-  const auto orig_pwd_container = get_and_verify_password();
-  if(orig_pwd_container == boost::none)
-  {
-    fail_msg_writer() << tr("Your original password was incorrect.");
-    return true;
-  }
-
   if (args.size() < 2)
   {
     fail_msg_writer() << tr("usage: make_multisig <threshold> <multisiginfo1> [<multisiginfo2>...]");
@@ -912,6 +938,13 @@ bool simple_wallet::make_multisig(const std::vector<std::string> &args)
   if (!string_tools::get_xtype_from_string(threshold, args[0]))
   {
     fail_msg_writer() << tr("Invalid threshold");
+    return true;
+  }
+
+  const auto orig_pwd_container = get_and_verify_password();
+  if(orig_pwd_container == boost::none)
+  {
+    fail_msg_writer() << tr("Your original password was incorrect.");
     return true;
   }
 
@@ -956,6 +989,14 @@ bool simple_wallet::finalize_multisig(const std::vector<std::string> &args)
     fail_msg_writer() << tr("command not supported by HW wallet");
     return true;
   }
+
+  const auto pwd_container = get_and_verify_password();
+  if(pwd_container == boost::none)
+  {
+    fail_msg_writer() << tr("Your original password was incorrect.");
+    return true;
+  }
+
   if (!m_wallet->multisig(&ready))
   {
     fail_msg_writer() << tr("This wallet is not multisig");
@@ -967,12 +1008,7 @@ bool simple_wallet::finalize_multisig(const std::vector<std::string> &args)
     return true;
   }
 
-  const auto orig_pwd_container = get_and_verify_password();
-  if(orig_pwd_container == boost::none)
-  {
-    fail_msg_writer() << tr("Your original password was incorrect.");
-    return true;
-  }
+  LOCK_IDLE_SCOPE();
 
   if (args.size() < 2)
   {
@@ -982,7 +1018,7 @@ bool simple_wallet::finalize_multisig(const std::vector<std::string> &args)
 
   try
   {
-    if (!m_wallet->finalize_multisig(orig_pwd_container->password(), args))
+    if (!m_wallet->finalize_multisig(pwd_container->password(), args))
     {
       fail_msg_writer() << tr("Failed to finalize multisig");
       return true;
@@ -1020,8 +1056,8 @@ bool simple_wallet::export_multisig(const std::vector<std::string> &args)
     fail_msg_writer() << tr("usage: export_multisig_info <filename>");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password())
-    return true;
+
+  SCOPED_WALLET_UNLOCK();
 
   const std::string filename = args[0];
   if (m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
@@ -1072,8 +1108,8 @@ bool simple_wallet::import_multisig(const std::vector<std::string> &args)
     fail_msg_writer() << tr("usage: import_multisig_info <filename1> [<filename2>...] - one for each other participant");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password())
-    return true;
+
+  SCOPED_WALLET_UNLOCK();
 
   std::vector<cryptonote::blobdata> info;
   for (size_t n = 0; n < args.size(); ++n)
@@ -1089,11 +1125,11 @@ bool simple_wallet::import_multisig(const std::vector<std::string> &args)
     info.push_back(std::move(data));
   }
 
-  LOCK_IDLE_SCOPE();
-
   // all read and parsed, actually import
   try
   {
+    m_in_manual_refresh.store(true, std::memory_order_relaxed);
+    epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
     size_t n_outputs = m_wallet->import_multisig(info);
     // Clear line "Height xxx of xxx"
     std::cout << "\r                                                                \r";
@@ -1151,7 +1187,8 @@ bool simple_wallet::sign_multisig(const std::vector<std::string> &args)
     fail_msg_writer() << tr("usage: sign_multisig <filename>");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
 
   std::string filename = args[0];
   std::vector<crypto::hash> txids;
@@ -1224,7 +1261,8 @@ bool simple_wallet::submit_multisig(const std::vector<std::string> &args)
     fail_msg_writer() << tr("usage: submit_multisig <filename>");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
 
   if (!try_connect_to_daemon())
     return true;
@@ -1291,7 +1329,8 @@ bool simple_wallet::export_raw_multisig(const std::vector<std::string> &args)
     fail_msg_writer() << tr("usage: export_raw_multisig <filename>");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
 
   std::string filename = args[0];
   if (m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
@@ -1913,6 +1952,14 @@ bool simple_wallet::set_ask_password(const std::vector<std::string> &args/* = st
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool r) {
+      const bool cur_r = m_wallet->ask_password();
+      if (!m_wallet->watch_only())
+      {
+        if (cur_r && !r)
+          m_wallet->decrypt_keys(pwd_container->password());
+        else if (!cur_r && r)
+          m_wallet->encrypt_keys(pwd_container->password());
+      }
       m_wallet->ask_password(r);
       m_wallet->rewrite(m_wallet_file, pwd_container->password());
     });
@@ -3175,7 +3222,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       m_wallet_file = m_generate_from_json;
       try
       {
-        m_wallet = tools::wallet2::make_from_json(vm, m_wallet_file, password_prompter);
+        m_wallet = tools::wallet2::make_from_json(vm, false, m_wallet_file, password_prompter);
       }
       catch (const std::exception &e)
       {
@@ -3479,7 +3526,7 @@ boost::optional<tools::password_container> simple_wallet::get_and_verify_passwor
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   const crypto::secret_key& recovery_key, bool recover, bool two_random, const std::string &old_language)
 {
-  auto rc = tools::wallet2::make_new(vm, password_prompter);
+  auto rc = tools::wallet2::make_new(vm, false, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
@@ -3534,7 +3581,10 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
     recovery_val = m_wallet->generate(m_wallet_file, std::move(rc.second).password(), recovery_key, recover, two_random, create_address_file);
     message_writer(console_color_white, true) << tr("Generated new wallet: ")
       << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    std::cout << tr("View key: ") << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_view_secret_key) << ENDL;
+    PAUSE_READLINE();
+    std::cout << tr("View key: ");
+    print_secret_key(m_wallet->get_account().get_keys().m_view_secret_key);
+    putchar('\n');
   }
   catch (const std::exception& e)
   {
@@ -3571,7 +3621,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
   const cryptonote::account_public_address& address, const boost::optional<crypto::secret_key>& spendkey,
   const crypto::secret_key& viewkey)
 {
-  auto rc = tools::wallet2::make_new(vm, password_prompter);
+  auto rc = tools::wallet2::make_new(vm, false, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
@@ -3617,7 +3667,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
 //----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
                                const std::string &device_name) {
-  auto rc = tools::wallet2::make_new(vm, password_prompter);
+  auto rc = tools::wallet2::make_new(vm, false, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
@@ -3653,7 +3703,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
     const epee::wipeable_string &multisig_keys, const std::string &old_language)
 {
-  auto rc = tools::wallet2::make_new(vm, password_prompter);
+  auto rc = tools::wallet2::make_new(vm, false, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
@@ -3724,7 +3774,7 @@ bool simple_wallet::open_wallet(const boost::program_options::variables_map& vm)
   epee::wipeable_string password;
   try
   {
-    auto rc = tools::wallet2::make_from_file(vm, m_wallet_file, password_prompter);
+    auto rc = tools::wallet2::make_from_file(vm, false, m_wallet_file, password_prompter);
     m_wallet = std::move(rc.first);
     password = std::move(std::move(rc.second).password());
     if (!m_wallet)
@@ -3751,7 +3801,12 @@ bool simple_wallet::open_wallet(const boost::program_options::variables_map& vm)
     // NOTE: this is_deprecated() refers to the wallet file format before becoming JSON. It does not refer to the "old english" seed words form of "deprecated" used elsewhere.
     if (m_wallet->is_deprecated())
     {
-      if (m_wallet->is_deterministic())
+      bool is_deterministic;
+      {
+        SCOPED_WALLET_UNLOCK();
+        is_deterministic = m_wallet->is_deterministic();
+      }
+      if (is_deterministic)
       {
         message_writer(console_color_green, false) << "\n" << tr("You had been using "
           "a deprecated version of the wallet. Please proceed to upgrade your wallet.\n");
@@ -3989,7 +4044,7 @@ bool simple_wallet::set_daemon(const std::vector<std::string>& args)
       daemon_url = args[0];
     }
     LOCK_IDLE_SCOPE();
-    m_wallet->init(daemon_url);
+    m_wallet->init(false, daemon_url);
 
     if (args.size() == 2)
     {
@@ -4101,6 +4156,32 @@ void simple_wallet::on_money_spent(uint64_t height, const crypto::hash &txid, co
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx)
 {
+}
+//----------------------------------------------------------------------------------------------------
+boost::optional<epee::wipeable_string> simple_wallet::on_get_password(const char *reason)
+{
+  // can't ask for password from a background thread
+  if (!m_in_manual_refresh.load(std::memory_order_relaxed))
+  {
+    message_writer(console_color_red, false) << tr("Password needed - use the refresh command");
+    m_cmd_binder.print_prompt();
+    return boost::none;
+  }
+
+#ifdef HAVE_READLINE
+  rdln::suspend_readline pause_readline;
+#endif
+  std::string msg = tr("Enter password");
+  if (reason && *reason)
+    msg += std::string(" (") + reason + ")";
+  auto pwd_container = tools::password_container::prompt(false, msg.c_str());
+  if (!pwd_container)
+  {
+    MERROR("Failed to read password");
+    return boost::none;
+  }
+
+  return pwd_container->password();
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::refresh_main(uint64_t start_height, bool reset, bool is_init)
@@ -4578,11 +4659,10 @@ bool simple_wallet::print_ring_members(const std::vector<tools::wallet2::pending
 bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::string> &args_)
 {
 //  "transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] <address> <amount> [<payment_id>]"
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   if (!try_connect_to_daemon())
     return true;
 
-  LOCK_IDLE_SCOPE();
+  SCOPED_WALLET_UNLOCK();
 
   std::vector<std::string> local_args = args_;
 
@@ -4983,11 +5063,11 @@ bool simple_wallet::locked_sweep_all(const std::vector<std::string> &args_)
 
 bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
 {
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   if (!try_connect_to_daemon())
     return true;
 
-  LOCK_IDLE_SCOPE();
+  SCOPED_WALLET_UNLOCK();
+
   try
   {
     // figure out what tx will be necessary
@@ -5100,7 +5180,6 @@ bool simple_wallet::sweep_main(uint64_t below, bool locked, const std::vector<st
     return true;
   }
 
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   if (!try_connect_to_daemon())
     return true;
 
@@ -5262,7 +5341,7 @@ bool simple_wallet::sweep_main(uint64_t below, bool locked, const std::vector<st
      }
   }
 
-  LOCK_IDLE_SCOPE();
+  SCOPED_WALLET_UNLOCK();
 
   try
   {
@@ -5364,7 +5443,7 @@ bool simple_wallet::sweep_main(uint64_t below, bool locked, const std::vector<st
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
 {
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+  SCOPED_WALLET_UNLOCK();
   if (!try_connect_to_daemon())
     return true;
 
@@ -5799,7 +5878,8 @@ bool simple_wallet::sign_transfer(const std::vector<std::string> &args_)
     fail_msg_writer() << tr("usage: sign_transfer [export_raw]");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
   const bool export_raw = args_.size() == 1;
 
   std::vector<tools::wallet2::pending_tx> ptx;
@@ -5888,7 +5968,6 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
     fail_msg_writer() << tr("usage: get_tx_key <txid>");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
 
   crypto::hash txid;
   if (!epee::string_tools::hex_to_pod(local_args[0], txid))
@@ -5897,7 +5976,7 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
     return true;
   }
 
-  LOCK_IDLE_SCOPE();
+  SCOPED_WALLET_UNLOCK();
 
   crypto::secret_key tx_key;
   std::vector<crypto::secret_key> additional_tx_keys;
@@ -6002,7 +6081,7 @@ bool simple_wallet::get_tx_proof(const std::vector<std::string> &args)
     return true;
   }
 
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+  SCOPED_WALLET_UNLOCK();
 
   try
   {
@@ -6217,7 +6296,7 @@ bool simple_wallet::get_spend_proof(const std::vector<std::string> &args)
     return true;
   }
 
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+  SCOPED_WALLET_UNLOCK();
 
   try
   {
@@ -6312,9 +6391,7 @@ bool simple_wallet::get_reserve_proof(const std::vector<std::string> &args)
     return true;
   }
 
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
-
-  LOCK_IDLE_SCOPE();
+  SCOPED_WALLET_UNLOCK();
 
   try
   {
@@ -6567,6 +6644,9 @@ bool simple_wallet::show_transfers(const std::vector<std::string> &args_)
   if (pool) {
     try
     {
+      m_in_manual_refresh.store(true, std::memory_order_relaxed);
+      epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
+
       m_wallet->update_pool_state();
       std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> payments;
       m_wallet->get_unconfirmed_payments(payments, m_current_subaddress_account, subaddr_indices);
@@ -7415,7 +7495,8 @@ bool simple_wallet::sign(const std::vector<std::string> &args)
     fail_msg_writer() << tr("This wallet is multisig and cannot sign");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
   std::string filename = args[0];
   std::string data;
   bool r = epee::file_io_utils::load_file_to_string(filename, data);
@@ -7484,14 +7565,14 @@ bool simple_wallet::export_key_images(const std::vector<std::string> &args)
     fail_msg_writer() << tr("wallet is watch-only and cannot export key images");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
   std::string filename = args[0];
   if (m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
     return true;
 
   try
   {
-    LOCK_IDLE_SCOPE();
     if (!m_wallet->export_key_images(filename))
     {
       fail_msg_writer() << tr("failed to save file ") << filename;
@@ -7563,12 +7644,12 @@ bool simple_wallet::export_outputs(const std::vector<std::string> &args)
     fail_msg_writer() << tr("usage: export_outputs <filename>");
     return true;
   }
-  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+
+  SCOPED_WALLET_UNLOCK();
   std::string filename = args[0];
   if (m_wallet->confirm_export_overwrite() && !check_file_overwrite(filename))
     return true;
 
-  LOCK_IDLE_SCOPE();
   try
   {
     std::string data = m_wallet->export_outputs_to_str();
@@ -7614,7 +7695,7 @@ bool simple_wallet::import_outputs(const std::vector<std::string> &args)
 
   try
   {
-    LOCK_IDLE_SCOPE();
+    SCOPED_WALLET_UNLOCK();
     size_t n_outputs = m_wallet->import_outputs_from_str(data);
     success_msg_writer() << boost::lexical_cast<std::string>(n_outputs) << " outputs imported";
   }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2817,6 +2817,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
           m_recovery_key = cryptonote::decrypt_key(m_recovery_key, seed_pass);
       }
     }
+    epee::wipeable_string password;
     if (!m_generate_from_view_key.empty())
     {
       m_wallet_file = m_generate_from_view_key;
@@ -2869,8 +2870,9 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         return false;
       }
 
-      bool r = new_wallet(vm, info.address, boost::none, viewkey);
+      auto r = new_wallet(vm, info.address, boost::none, viewkey);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
+      password = *r;
     }
     else if (!m_generate_from_spend_key.empty())
     {
@@ -2888,8 +2890,9 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         fail_msg_writer() << tr("failed to parse spend key secret key");
         return false;
       }
-      bool r = new_wallet(vm, m_recovery_key, true, false, "");
+      auto r = new_wallet(vm, m_recovery_key, true, false, "");
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
+      password = *r;
     }
     else if (!m_generate_from_keys.empty())
     {
@@ -2966,8 +2969,9 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         fail_msg_writer() << tr("view key does not match standard address");
         return false;
       }
-      bool r = new_wallet(vm, info.address, spendkey, viewkey);
+      auto r = new_wallet(vm, info.address, spendkey, viewkey);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
+      password = *r;
     }
     
     // Asks user for all the data required to merge secret keys from multisig wallets into one master wallet, which then gets full control of the multisig wallet. The resulting wallet will be the same as any other regular wallet.
@@ -3100,8 +3104,9 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       }
       
       // create wallet
-      bool r = new_wallet(vm, info.address, spendkey, viewkey);
+      auto r = new_wallet(vm, info.address, spendkey, viewkey);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
+      password = *r;
     }
     
     else if (!m_generate_from_json.empty())
@@ -3123,8 +3128,9 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
     {
       m_wallet_file = m_generate_from_device;
       // create wallet
-      bool r = new_wallet(vm, "Ledger");
+      auto r = new_wallet(vm, "Ledger");
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
+      password = *r;
       // if no block_height is specified, assume its a new account and start it "now"
       if(m_wallet->get_refresh_from_block_height() == 0) {
         {
@@ -3149,12 +3155,13 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         return false;
       }
       m_wallet_file = m_generate_new;
-      bool r;
+      boost::optional<epee::wipeable_string> r;
       if (m_restore_multisig_wallet)
         r = new_wallet(vm, multisig_keys, old_language);
       else
         r = new_wallet(vm, m_recovery_key, m_restore_deterministic_wallet, m_non_deterministic, old_language);
       CHECK_AND_ASSERT_MES(r, false, tr("account creation failed"));
+      password = *r;
     }
 
     if (m_restoring && m_generate_from_json.empty() && m_generate_from_device.empty())
@@ -3236,6 +3243,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       }
       m_wallet->set_refresh_from_block_height(m_restore_height);
     }
+    m_wallet->rewrite(m_wallet_file, password);
   }
   else
   {
@@ -3407,15 +3415,16 @@ boost::optional<tools::password_container> simple_wallet::get_and_verify_passwor
   return pwd_container;
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
+boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   const crypto::secret_key& recovery_key, bool recover, bool two_random, const std::string &old_language)
 {
   auto rc = tools::wallet2::make_new(vm, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
-    return false;
+    return {};
   }
+  epee::wipeable_string password = rc.second.password();
 
   if (!m_subaddress_lookahead.empty())
   {
@@ -3451,7 +3460,7 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
     }
     mnemonic_language = get_mnemonic_language();
     if (mnemonic_language.empty())
-      return false;
+      return {};
   }
 
   m_wallet->set_seed_language(mnemonic_language);
@@ -3469,7 +3478,7 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   catch (const std::exception& e)
   {
     fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
-    return false;
+    return {};
   }
 
   // convert rng value to electrum-style word list
@@ -3494,10 +3503,10 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   }
   success_msg_writer() << "**********************************************************************";
 
-  return true;
+  return std::move(password);
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
+boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   const cryptonote::account_public_address& address, const boost::optional<crypto::secret_key>& spendkey,
   const crypto::secret_key& viewkey)
 {
@@ -3505,8 +3514,9 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
-    return false;
+    return {};
   }
+  epee::wipeable_string password = rc.second.password();
 
   if (!m_subaddress_lookahead.empty())
   {
@@ -3536,22 +3546,23 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   catch (const std::exception& e)
   {
     fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
-    return false;
+    return {};
   }
 
 
-  return true;
+  return std::move(password);
 }
 
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
+boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
                                const std::string &device_name) {
   auto rc = tools::wallet2::make_new(vm, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
-    return false;
+    return {};
   }
+  epee::wipeable_string password = rc.second.password();
 
   if (!m_subaddress_lookahead.empty())
   {
@@ -3572,21 +3583,22 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   catch (const std::exception& e)
   {
     fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
-    return false;
+    return {};
   }
 
-  return true;
+  return std::move(password);
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
+boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
     const std::string &multisig_keys, const std::string &old_language)
 {
   auto rc = tools::wallet2::make_new(vm, password_prompter);
   m_wallet = std::move(rc.first);
   if (!m_wallet)
   {
-    return false;
+    return {};
   }
+  epee::wipeable_string password = rc.second.password();
 
   if (!m_subaddress_lookahead.empty())
   {
@@ -3616,7 +3628,7 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
     if (!m_wallet->multisig(&ready, &threshold, &total) || !ready)
     {
       fail_msg_writer() << tr("failed to generate new mutlisig wallet");
-      return false;
+      return {};
     }
     message_writer(console_color_white, true) << boost::format(tr("Generated new %u/%u multisig wallet: ")) % threshold % total
       << m_wallet->get_account().get_public_address_str(m_wallet->nettype());
@@ -3624,10 +3636,10 @@ bool simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
   catch (const std::exception& e)
   {
     fail_msg_writer() << tr("failed to generate new wallet: ") << e.what();
-    return false;
+    return {};
   }
 
-  return true;
+  return std::move(password);
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::open_wallet(const boost::program_options::variables_map& vm)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -1823,6 +1823,7 @@ bool simple_wallet::set_auto_refresh(const std::vector<std::string> &args/* = st
   if (pwd_container)
   {
     parse_bool_and_use(args[1], [&](bool auto_refresh) {
+      m_auto_refresh_enabled.store(false, std::memory_order_relaxed);
       m_wallet->auto_refresh(auto_refresh);
       m_idle_mutex.lock();
       m_auto_refresh_enabled.store(auto_refresh, std::memory_order_relaxed);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -150,12 +150,31 @@ namespace
   //
   // Note also that input for passwords is NOT translated, to remain compatible with any
   // passwords containing special characters that predate this switch to UTF-8 support.
-  static std::string cp850_to_utf8(const std::string &cp850_str)
+  template<typename T>
+  static T cp850_to_utf8(const T &cp850_str)
   {
     boost::locale::generator gen;
     gen.locale_cache_enabled(true);
     std::locale loc = gen("en_US.CP850");
-    return boost::locale::conv::to_utf<char>(cp850_str, loc);
+    const boost::locale::conv::method_type how = boost::locale::conv::default_method;
+    T result;
+    const char *begin = cp850_str.data();
+    const char *end = begin + cp850_str.size();
+    result.reserve(end-begin);
+    typedef std::back_insert_iterator<T> inserter_type;
+    inserter_type inserter(result);
+    boost::locale::utf::code_point c;
+    while(begin!=end) {
+        c=boost::locale::utf::utf_traits<char>::template decode<char const *>(begin,end);
+        if(c==boost::locale::utf::illegal || c==boost::locale::utf::incomplete) {
+            if(how==boost::locale::conv::stop)
+                throw boost::locale::conv::conversion_error();
+        }
+        else {
+            boost::locale::utf::utf_traits<char>::template encode<inserter_type>(c,inserter);
+        }
+    }
+    return result;
   }
 #endif
 
@@ -173,6 +192,28 @@ namespace
 #endif
 
     return epee::string_tools::trim(buf);
+  }
+
+  epee::wipeable_string input_secure_line(const std::string& prompt)
+  {
+#ifdef HAVE_READLINE
+    rdln::suspend_readline pause_readline;
+#endif
+    auto pwd_container = tools::password_container::prompt(false, prompt.c_str(), false);
+    if (!pwd_container)
+    {
+      MERROR("Failed to read secure line");
+      return "";
+    }
+
+    epee::wipeable_string buf = pwd_container->password();
+
+#ifdef WIN32
+    buf = cp850_to_utf8(buf);
+#endif
+
+    buf.trim();
+    return buf;
   }
 
   boost::optional<tools::password_container> password_prompter(const char *prompt, bool verify)
@@ -593,7 +634,7 @@ bool simple_wallet::spendkey(const std::vector<std::string> &args/* = std::vecto
 bool simple_wallet::print_seed(bool encrypted)
 {
   bool success =  false;
-  std::string seed;
+  epee::wipeable_string seed;
   bool ready, multisig;
 
   if (m_wallet->key_on_device())
@@ -2681,28 +2722,45 @@ bool simple_wallet::ask_wallet_create_if_needed()
  * \brief Prints the seed with a nice message
  * \param seed seed to print
  */
-void simple_wallet::print_seed(std::string seed)
+void simple_wallet::print_seed(const epee::wipeable_string &seed)
 {
   success_msg_writer(true) << "\n" << tr("NOTE: the following 25 words can be used to recover access to your wallet. "
     "Write them down and store them somewhere safe and secure. Please do not store them in "
     "your email or on file storage services outside of your immediate control.\n");
-  boost::replace_nth(seed, " ", 15, "\n");
-  boost::replace_nth(seed, " ", 7, "\n");
   // don't log
-  std::cout << seed << std::endl;
+  int space_index = 0;
+  size_t len  = seed.size();
+  for (const char *ptr = seed.data(); len--; ++ptr)
+  {
+    if (*ptr == ' ')
+    {
+      if (space_index == 15 || space_index == 7)
+        putchar('\n');
+      else
+        putchar(*ptr);
+      ++space_index;
+    }
+    else
+      putchar(*ptr);
+  }
+  putchar('\n');
+  fflush(stdout);
 }
 //----------------------------------------------------------------------------------------------------
-static bool might_be_partial_seed(std::string words)
+static bool might_be_partial_seed(const epee::wipeable_string &words)
 {
-  std::vector<std::string> seed;
+  std::vector<epee::wipeable_string> seed;
 
-  boost::algorithm::trim(words);
-  boost::split(seed, words, boost::is_any_of(" "), boost::token_compress_on);
+  words.split(seed);
   return seed.size() < 24;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::init(const boost::program_options::variables_map& vm)
 {
+  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){
+    m_electrum_seed.wipe();
+  });
+
   const bool testnet = tools::wallet2::has_testnet_option(vm);
   const bool stagenet = tools::wallet2::has_stagenet_option(vm);
   if (testnet && stagenet)
@@ -2712,7 +2770,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
   }
   const network_type nettype = testnet ? TESTNET : stagenet ? STAGENET : MAINNET;
 
-  std::string multisig_keys;
+  epee::wipeable_string multisig_keys;
 
   if (!handle_command_line(vm))
     return false;
@@ -2754,8 +2812,8 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       {
         if (m_restore_multisig_wallet)
         {
-            const char *prompt = "Specify multisig seed: ";
-            m_electrum_seed = input_line(prompt);
+            const char *prompt = "Specify multisig seed";
+            m_electrum_seed = input_secure_line(prompt);
             if (std::cin.eof())
               return false;
             if (m_electrum_seed.empty())
@@ -2769,8 +2827,8 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
           m_electrum_seed = "";
           do
           {
-            const char *prompt = m_electrum_seed.empty() ? "Specify Electrum seed: " : "Electrum seed continued: ";
-            std::string electrum_seed = input_line(prompt);
+            const char *prompt = m_electrum_seed.empty() ? "Specify Electrum seed" : "Electrum seed continued";
+            epee::wipeable_string electrum_seed = input_secure_line(prompt);
             if (std::cin.eof())
               return false;
             if (electrum_seed.empty())
@@ -2778,18 +2836,21 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
               fail_msg_writer() << tr("specify a recovery parameter with the --electrum-seed=\"words list here\"");
               return false;
             }
-            m_electrum_seed += electrum_seed + " ";
+            m_electrum_seed += electrum_seed;
+            m_electrum_seed += ' ';
           } while (might_be_partial_seed(m_electrum_seed));
         }
       }
 
       if (m_restore_multisig_wallet)
       {
-        if (!epee::string_tools::parse_hexstr_to_binbuff(m_electrum_seed, multisig_keys))
+        const boost::optional<epee::wipeable_string> parsed = m_electrum_seed.parse_hexstr();
+        if (!parsed)
         {
           fail_msg_writer() << tr("Multisig seed failed verification");
           return false;
         }
+        multisig_keys = *parsed;
       }
       else
       {
@@ -2811,7 +2872,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
           crypto::secret_key key;
           crypto::cn_slow_hash(seed_pass.data(), seed_pass.size(), (crypto::hash&)key);
           sc_reduce32((unsigned char*)key.data);
-          multisig_keys = m_wallet->decrypt(multisig_keys, key, true);
+          multisig_keys = m_wallet->decrypt<epee::wipeable_string>(std::string(multisig_keys.data(), multisig_keys.size()), key, true);
         }
         else
           m_recovery_key = cryptonote::decrypt_key(m_recovery_key, seed_pass);
@@ -3482,7 +3543,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
   }
 
   // convert rng value to electrum-style word list
-  std::string electrum_words;
+  epee::wipeable_string electrum_words;
 
   crypto::ElectrumWords::bytes_to_words(recovery_val, electrum_words, mnemonic_language);
 
@@ -3590,7 +3651,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
 }
 //----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
-    const std::string &multisig_keys, const std::string &old_language)
+    const epee::wipeable_string &multisig_keys, const std::string &old_language)
 {
   auto rc = tools::wallet2::make_new(vm, password_prompter);
   m_wallet = std::move(rc.first);
@@ -3701,7 +3762,7 @@ bool simple_wallet::open_wallet(const boost::program_options::variables_map& vm)
         m_wallet->rewrite(m_wallet_file, password);
 
         // Display the seed
-        std::string seed;
+        epee::wipeable_string seed;
         m_wallet->get_seed(seed);
         print_seed(seed);
       }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2301,6 +2301,10 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::get_tx_key, this, _1),
                            tr("get_tx_key <txid>"),
                            tr("Get the transaction key (r) for a given <txid>."));
+  m_cmd_binder.set_handler("set_tx_key",
+                           boost::bind(&simple_wallet::set_tx_key, this, _1),
+                           tr("set_tx_key <txid> <tx_key>"),
+                           tr("Set the transaction key (r) for a given <txid> in case the tx was made by some other device or 3rd party wallet."));
   m_cmd_binder.set_handler("check_tx_key",
                            boost::bind(&simple_wallet::check_tx_key, this, _1),
                            tr("check_tx_key <txid> <txkey> <address>"),
@@ -5838,6 +5842,64 @@ bool simple_wallet::get_tx_key(const std::vector<std::string> &args_)
     fail_msg_writer() << tr("no tx keys found for this txid");
     return true;
   }
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::set_tx_key(const std::vector<std::string> &args_)
+{
+  std::vector<std::string> local_args = args_;
+
+  if(local_args.size() != 2) {
+    fail_msg_writer() << tr("usage: set_tx_key <txid> <tx_key>");
+    return true;
+  }
+
+  crypto::hash txid;
+  if (!epee::string_tools::hex_to_pod(local_args[0], txid))
+  {
+    fail_msg_writer() << tr("failed to parse txid");
+    return true;
+  }
+
+  crypto::secret_key tx_key;
+  std::vector<crypto::secret_key> additional_tx_keys;
+  try
+  {
+    if (!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), tx_key))
+    {
+      fail_msg_writer() << tr("failed to parse tx_key");
+      return true;
+    }
+    while(true)
+    {
+      local_args[1] = local_args[1].substr(64);
+      if (local_args[1].empty())
+        break;
+      additional_tx_keys.resize(additional_tx_keys.size() + 1);
+      if (!epee::string_tools::hex_to_pod(local_args[1].substr(0, 64), additional_tx_keys.back()))
+      {
+        fail_msg_writer() << tr("failed to parse tx_key");
+        return true;
+      }
+    }
+  }
+  catch (const std::out_of_range &e)
+  {
+    fail_msg_writer() << tr("failed to parse tx_key");
+    return true;
+  }
+
+  LOCK_IDLE_SCOPE();
+
+  try
+  {
+    m_wallet->set_tx_key(txid, tx_key, additional_tx_keys);
+    success_msg_writer() << tr("Tx key successfully stored.");
+  }
+  catch (const std::exception &e)
+  {
+    fail_msg_writer() << tr("Failed to store tx key: ") << e.what();
+  }
+  return true;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::get_tx_proof(const std::vector<std::string> &args)

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -177,6 +177,7 @@ namespace cryptonote
     bool rescan_spent(const std::vector<std::string> &args);
     bool set_log(const std::vector<std::string> &args);
     bool get_tx_key(const std::vector<std::string> &args);
+    bool set_tx_key(const std::vector<std::string> &args);
     bool check_tx_key(const std::vector<std::string> &args);
     bool get_tx_proof(const std::vector<std::string> &args);
     bool check_tx_proof(const std::vector<std::string> &args);

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -262,6 +262,7 @@ namespace cryptonote
     virtual void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index);
     virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index);
     virtual void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx);
+    virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason);
     //----------------------------------------------------------
 
     friend class refresh_progress_reporter_t;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -91,13 +91,13 @@ namespace cryptonote
     //! \return Prompts user for password and verifies against local file. Logs on error and returns `none`
     boost::optional<tools::password_container> get_and_verify_password() const;
 
-    bool new_wallet(const boost::program_options::variables_map& vm, const crypto::secret_key& recovery_key,
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const crypto::secret_key& recovery_key,
         bool recover, bool two_random, const std::string &old_language);
-    bool new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
         const boost::optional<crypto::secret_key>& spendkey, const crypto::secret_key& viewkey);
-    bool new_wallet(const boost::program_options::variables_map& vm,
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm,
         const std::string &multisig_keys, const std::string &old_language);
-    bool new_wallet(const boost::program_options::variables_map& vm, const std::string& device_name);
+    boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const std::string& device_name);
     bool open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();
 

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -44,6 +44,7 @@
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "wallet/wallet2.h"
 #include "console_handler.h"
+#include "wipeable_string.h"
 #include "common/i18n.h"
 #include "common/password.h"
 #include "crypto/crypto.h"  // for definition of crypto::secret_key
@@ -96,7 +97,7 @@ namespace cryptonote
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const cryptonote::account_public_address& address,
         const boost::optional<crypto::secret_key>& spendkey, const crypto::secret_key& viewkey);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm,
-        const std::string &multisig_keys, const std::string &old_language);
+        const epee::wipeable_string &multisig_keys, const std::string &old_language);
     boost::optional<epee::wipeable_string> new_wallet(const boost::program_options::variables_map& vm, const std::string& device_name);
     bool open_wallet(const boost::program_options::variables_map& vm);
     bool close_wallet();
@@ -238,7 +239,7 @@ namespace cryptonote
      * \brief Prints the seed with a nice message
      * \param seed seed to print
      */
-    void print_seed(std::string seed);
+    void print_seed(const epee::wipeable_string &seed);
 
     /*!
      * \brief Gets the word seed language from the user.
@@ -329,7 +330,7 @@ namespace cryptonote
     std::string m_import_path;
     std::string m_subaddress_lookahead;
 
-    std::string m_electrum_seed;  // electrum-style seed parameter
+    epee::wipeable_string m_electrum_seed;  // electrum-style seed parameter
 
     crypto::secret_key m_recovery_key;  // recovery key (used as random for wallet gen)
     bool m_restore_deterministic_wallet;  // recover flag

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -51,6 +51,9 @@ bool isAddressLocal(const std::string &address)
 void onStartup()
 {
     tools::on_startup();
+#ifdef NDEBUG
+    tools::disable_core_dumps();
+#endif
 }
 
 }

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -365,7 +365,7 @@ void Wallet::error(const std::string &category, const std::string &str) {
 }
 
 ///////////////////////// WalletImpl implementation ////////////////////////
-WalletImpl::WalletImpl(NetworkType nettype, bool restricted, uint64_t kdf_rounds)
+WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     :m_wallet(nullptr)
     , m_status(Wallet::Status_Ok)
     , m_trustedDaemon(false)
@@ -376,7 +376,7 @@ WalletImpl::WalletImpl(NetworkType nettype, bool restricted, uint64_t kdf_rounds
     , m_rebuildWalletCache(false)
     , m_is_connected(false)
 {
-    m_wallet = new tools::wallet2(static_cast<cryptonote::network_type>(nettype), restricted, kdf_rounds);
+    m_wallet = new tools::wallet2(static_cast<cryptonote::network_type>(nettype), kdf_rounds);
     m_history = new TransactionHistoryImpl(this);
     m_wallet2Callback = new Wallet2CallbackImpl(this);
     m_wallet->callback(m_wallet2Callback);

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -732,10 +732,10 @@ bool WalletImpl::close(bool store)
 
 std::string WalletImpl::seed() const
 {
-    std::string seed;
+    epee::wipeable_string seed;
     if (m_wallet)
         m_wallet->get_seed(seed);
-    return seed;
+    return std::string(seed.data(), seed.size()); // TODO
 }
 
 std::string WalletImpl::getSeedLanguage() const

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2033,7 +2033,8 @@ bool WalletImpl::isNewWallet() const
 
 bool WalletImpl::doInit(const string &daemon_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
-    if (!m_wallet->init(daemon_address, m_daemon_login, upper_transaction_size_limit, ssl))
+    // claim RPC so there's no in-memory encryption for now
+    if (!m_wallet->init(true, daemon_address, m_daemon_login, upper_transaction_size_limit, ssl))
        return false;
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -365,7 +365,7 @@ void Wallet::error(const std::string &category, const std::string &str) {
 }
 
 ///////////////////////// WalletImpl implementation ////////////////////////
-WalletImpl::WalletImpl(NetworkType nettype)
+WalletImpl::WalletImpl(NetworkType nettype, bool restricted, uint64_t kdf_rounds)
     :m_wallet(nullptr)
     , m_status(Wallet::Status_Ok)
     , m_trustedDaemon(false)
@@ -376,7 +376,7 @@ WalletImpl::WalletImpl(NetworkType nettype)
     , m_rebuildWalletCache(false)
     , m_is_connected(false)
 {
-    m_wallet = new tools::wallet2(static_cast<cryptonote::network_type>(nettype));
+    m_wallet = new tools::wallet2(static_cast<cryptonote::network_type>(nettype), restricted, kdf_rounds);
     m_history = new TransactionHistoryImpl(this);
     m_wallet2Callback = new Wallet2CallbackImpl(this);
     m_wallet->callback(m_wallet2Callback);

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -52,7 +52,7 @@ struct Wallet2CallbackImpl;
 class WalletImpl : public Wallet
 {
 public:
-    WalletImpl(NetworkType nettype = MAINNET, bool restricted = false, uint64_t kdf_rounds = 1);
+    WalletImpl(NetworkType nettype = MAINNET, uint64_t kdf_rounds = 1);
     ~WalletImpl();
     bool create(const std::string &path, const std::string &password,
                 const std::string &language);

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -52,7 +52,7 @@ struct Wallet2CallbackImpl;
 class WalletImpl : public Wallet
 {
 public:
-    WalletImpl(NetworkType nettype = MAINNET);
+    WalletImpl(NetworkType nettype = MAINNET, bool restricted = false, uint64_t kdf_rounds = 1);
     ~WalletImpl();
     bool create(const std::string &path, const std::string &password,
                 const std::string &language);

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -920,9 +920,10 @@ struct WalletManager
      * \param  password       Password of wallet file
      * \param  language       Language to be used to generate electrum seed mnemonic
      * \param  nettype        Network type
+     * \param  kdf_rounds     Number of rounds for key derivation function
      * \return                Wallet instance (Wallet::status() needs to be called to check if created successfully)
      */
-    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype) = 0;
+    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1) = 0;
     Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, bool testnet = false)      // deprecated
     {
         return createWallet(path, password, language, testnet ? TESTNET : MAINNET);
@@ -933,9 +934,10 @@ struct WalletManager
      * \param  path           Name of wallet file
      * \param  password       Password of wallet file
      * \param  nettype        Network type
+     * \param  kdf_rounds     Number of rounds for key derivation function
      * \return                Wallet instance (Wallet::status() needs to be called to check if opened successfully)
      */
-    virtual Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype) = 0;
+    virtual Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1) = 0;
     Wallet * openWallet(const std::string &path, const std::string &password, bool testnet = false)     // deprecated
     {
         return openWallet(path, password, testnet ? TESTNET : MAINNET);
@@ -948,10 +950,11 @@ struct WalletManager
      * \param  mnemonic       mnemonic (25 words electrum seed)
      * \param  nettype        Network type
      * \param  restoreHeight  restore from start height
+     * \param  kdf_rounds     Number of rounds for key derivation function
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
-                                    NetworkType nettype = MAINNET, uint64_t restoreHeight = 0) = 0;
+                                    NetworkType nettype = MAINNET, uint64_t restoreHeight = 0, uint64_t kdf_rounds = 1) = 0;
     Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     bool testnet = false, uint64_t restoreHeight = 0)           // deprecated
     {
@@ -983,6 +986,7 @@ struct WalletManager
      * \param  addressString  public address
      * \param  viewKeyString  view key
      * \param  spendKeyString spend key (optional)
+     * \param  kdf_rounds     Number of rounds for key derivation function
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * createWalletFromKeys(const std::string &path,
@@ -992,7 +996,8 @@ struct WalletManager
                                                     uint64_t restoreHeight,
                                                     const std::string &addressString,
                                                     const std::string &viewKeyString,
-                                                    const std::string &spendKeyString = "") = 0;
+                                                    const std::string &spendKeyString = "",
+                                                    uint64_t kdf_rounds = 1) = 0;
     Wallet * createWalletFromKeys(const std::string &path,
                                   const std::string &password,
                                   const std::string &language,
@@ -1043,6 +1048,7 @@ struct WalletManager
      * \param  deviceName           Device name
      * \param  restoreHeight        restore from start height (0 sets to current height)
      * \param  subaddressLookahead  Size of subaddress lookahead (empty sets to some default low value)
+     * \param  kdf_rounds           Number of rounds for key derivation function
      * \return                      Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * createWalletFromDevice(const std::string &path,
@@ -1050,7 +1056,8 @@ struct WalletManager
                                             NetworkType nettype,
                                             const std::string &deviceName,
                                             uint64_t restoreHeight = 0,
-                                            const std::string &subaddressLookahead = "") = 0;
+                                            const std::string &subaddressLookahead = "",
+                                            uint64_t kdf_rounds = 1) = 0;
 
     /*!
      * \brief Closes wallet. In case operation succeeded, wallet object deleted. in case operation failed, wallet object not deleted
@@ -1075,13 +1082,14 @@ struct WalletManager
      * @param keys_file_name - location of keys file
      * @param password - password to verify
      * @param no_spend_key - verify only view keys?
+     * @param kdf_rounds - number of rounds for key derivation function
      * @return - true if password is correct
      *
      * @note
      * This function will fail when the wallet keys file is opened because the wallet program locks the keys file.
      * In this case, Wallet::unlockKeysFile() and Wallet::lockKeysFile() need to be called before and after the call to this function, respectively.
      */
-    virtual bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key) const = 0;
+    virtual bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds = 1) const = 0;
 
     /*!
      * \brief findWallets - searches for the wallet files by given path name recursively

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -52,14 +52,14 @@ namespace Monero {
 Wallet *WalletManagerImpl::createWallet(const std::string &path, const std::string &password,
                                     const std::string &language, NetworkType nettype, uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
+    WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds);
     wallet->create(path, password, language);
     return wallet;
 }
 
 Wallet *WalletManagerImpl::openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
+    WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds);
     wallet->open(path, password);
     //Refresh addressBook
     wallet->addressBook()->refresh(); 
@@ -90,7 +90,7 @@ Wallet *WalletManagerImpl::recoveryWallet(const std::string &path,
                                                 uint64_t restoreHeight,
                                                 uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
+    WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
@@ -108,7 +108,7 @@ Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
                                                 const std::string &spendKeyString,
                                                 uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
+    WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
@@ -124,7 +124,7 @@ Wallet *WalletManagerImpl::createWalletFromDevice(const std::string &path,
                                                   const std::string &subaddressLookahead,
                                                   uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
+    WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -50,16 +50,16 @@ namespace epee {
 namespace Monero {
 
 Wallet *WalletManagerImpl::createWallet(const std::string &path, const std::string &password,
-                                    const std::string &language, NetworkType nettype)
+                                    const std::string &language, NetworkType nettype, uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype);
+    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
     wallet->create(path, password, language);
     return wallet;
 }
 
-Wallet *WalletManagerImpl::openWallet(const std::string &path, const std::string &password, NetworkType nettype)
+Wallet *WalletManagerImpl::openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype);
+    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
     wallet->open(path, password);
     //Refresh addressBook
     wallet->addressBook()->refresh(); 
@@ -87,9 +87,10 @@ Wallet *WalletManagerImpl::recoveryWallet(const std::string &path,
                                                 const std::string &password,
                                                 const std::string &mnemonic,
                                                 NetworkType nettype,
-                                                uint64_t restoreHeight)
+                                                uint64_t restoreHeight,
+                                                uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype);
+    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
@@ -104,9 +105,10 @@ Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
                                                 uint64_t restoreHeight,
                                                 const std::string &addressString,
                                                 const std::string &viewKeyString,
-                                                const std::string &spendKeyString)
+                                                const std::string &spendKeyString,
+                                                uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype);
+    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
@@ -119,9 +121,10 @@ Wallet *WalletManagerImpl::createWalletFromDevice(const std::string &path,
                                                   NetworkType nettype,
                                                   const std::string &deviceName,
                                                   uint64_t restoreHeight,
-                                                  const std::string &subaddressLookahead)
+                                                  const std::string &subaddressLookahead,
+                                                  uint64_t kdf_rounds)
 {
-    WalletImpl * wallet = new WalletImpl(nettype);
+    WalletImpl * wallet = new WalletImpl(nettype, false, kdf_rounds);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
@@ -159,9 +162,9 @@ bool WalletManagerImpl::walletExists(const std::string &path)
     return false;
 }
 
-bool WalletManagerImpl::verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key) const
+bool WalletManagerImpl::verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds) const
 {
-	    return tools::wallet2::verify_password(keys_file_name, password, no_spend_key, hw::get_device("default"));
+	    return tools::wallet2::verify_password(keys_file_name, password, no_spend_key, hw::get_device("default"), kdf_rounds);
 }
 
 std::vector<std::string> WalletManagerImpl::findWallets(const std::string &path)

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -39,13 +39,14 @@ class WalletManagerImpl : public WalletManager
 {
 public:
     Wallet * createWallet(const std::string &path, const std::string &password,
-                          const std::string &language, NetworkType nettype) override;
-    Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype) override;
+                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1) override;
+    Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1) override;
     virtual Wallet * recoveryWallet(const std::string &path,
                                        const std::string &password,
                                        const std::string &mnemonic,
                                        NetworkType nettype,
-                                       uint64_t restoreHeight) override;
+                                       uint64_t restoreHeight,
+                                       uint64_t kdf_rounds = 1) override;
     virtual Wallet * createWalletFromKeys(const std::string &path,
                                              const std::string &password,
                                              const std::string &language,
@@ -53,7 +54,8 @@ public:
                                              uint64_t restoreHeight,
                                              const std::string &addressString,
                                              const std::string &viewKeyString,
-                                             const std::string &spendKeyString = "") override;
+                                             const std::string &spendKeyString = "",
+                                             uint64_t kdf_rounds = 1) override;
     // next two methods are deprecated - use the above version which allow setting of a password
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &mnemonic, NetworkType nettype, uint64_t restoreHeight) override;
     // deprecated: use createWalletFromKeys(..., password, ...) instead
@@ -69,10 +71,11 @@ public:
                                             NetworkType nettype,
                                             const std::string &deviceName,
                                             uint64_t restoreHeight = 0,
-                                            const std::string &subaddressLookahead = "") override;
+                                            const std::string &subaddressLookahead = "",
+                                            uint64_t kdf_rounds = 1) override;
     virtual bool closeWallet(Wallet *wallet, bool store = true) override;
     bool walletExists(const std::string &path) override;
-    bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key) const override;
+    bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds = 1) const override;
     std::vector<std::string> findWallets(const std::string &path) override;
     std::string errorString() const override;
     void setDaemonAddress(const std::string &address) override;

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -146,7 +146,7 @@ boost::optional<std::string> NodeRPCProxy::get_earliest_height(uint8_t version, 
     CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
     CHECK_AND_ASSERT_MES(resp_t.status != CORE_RPC_STATUS_BUSY, resp_t.status, "Failed to connect to daemon");
     CHECK_AND_ASSERT_MES(resp_t.status == CORE_RPC_STATUS_OK, resp_t.status, "Failed to get hard fork status");
-    m_earliest_height[version] = resp_t.enabled ? resp_t.earliest_height : std::numeric_limits<uint64_t>::max();
+    m_earliest_height[version] = resp_t.earliest_height;
   }
 
   earliest_height = m_earliest_height[version];

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8796,7 +8796,7 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks) const
   result = m_node_rpc_proxy.get_earliest_height(version, earliest_height);
   throw_on_rpc_response_error(result, "get_hard_fork_info");
 
-  bool close_enough = height >=  earliest_height - early_blocks && earliest_height != std::numeric_limits<uint64_t>::max(); // start using the rules that many blocks beforehand
+  bool close_enough = height >=  earliest_height - early_blocks; // start using the rules that many blocks beforehand
   if (close_enough)
     LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
   else

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3000,7 +3000,7 @@ void wallet2::setup_keys(const epee::wipeable_string &password)
   }
 
   static_assert(HASH_SIZE == sizeof(crypto::chacha_key), "Mismatched sizes of hash and chacha key");
-  tools::scrubbed_arr<char, HASH_SIZE+1> cache_key_data;
+  epee::mlocked<tools::scrubbed_arr<char, HASH_SIZE+1>> cache_key_data;
   memcpy(cache_key_data.data(), &key, HASH_SIZE);
   cache_key_data[HASH_SIZE] = CACHE_KEY_TAIL;
   cn_fast_hash(cache_key_data.data(), HASH_SIZE+1, (crypto::hash&)m_cache_key);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8775,6 +8775,54 @@ bool wallet2::get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, s
   return true;
 }
 //----------------------------------------------------------------------------------------------------
+void wallet2::set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys)
+{
+  // fetch tx from daemon and check if secret keys agree with corresponding public keys
+  COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
+  req.txs_hashes.push_back(epee::string_tools::pod_to_hex(txid));
+  req.decode_as_json = false;
+  req.prune = false;
+  COMMAND_RPC_GET_TRANSACTIONS::response res = AUTO_VAL_INIT(res);
+  bool r;
+  {
+    const boost::lock_guard<boost::mutex> lock{m_daemon_rpc_mutex}; 
+    r = epee::net_utils::invoke_http_json("/gettransactions", req, res, m_http_client, rpc_timeout);
+  }
+  THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "gettransactions");
+  THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "gettransactions");
+  THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::wallet_internal_error, "gettransactions");
+  THROW_WALLET_EXCEPTION_IF(res.txs.size() != 1, error::wallet_internal_error,
+    "daemon returned wrong response for gettransactions, wrong txs count = " +
+    std::to_string(res.txs.size()) + ", expected 1");
+  cryptonote::blobdata bd;
+  THROW_WALLET_EXCEPTION_IF(!epee::string_tools::parse_hexstr_to_binbuff(res.txs[0].as_hex, bd), error::wallet_internal_error, "failed to parse tx from hexstr");
+  cryptonote::transaction tx;
+  crypto::hash tx_hash, tx_prefix_hash;
+  THROW_WALLET_EXCEPTION_IF(!cryptonote::parse_and_validate_tx_from_blob(bd, tx, tx_hash, tx_prefix_hash), error::wallet_internal_error, "failed to parse tx from blob");
+  THROW_WALLET_EXCEPTION_IF(tx_hash != txid, error::wallet_internal_error, "txid mismatch");
+  std::vector<tx_extra_field> tx_extra_fields;
+  THROW_WALLET_EXCEPTION_IF(!parse_tx_extra(tx.extra, tx_extra_fields), error::wallet_internal_error, "Transaction extra has unsupported format");
+  tx_extra_pub_key pub_key_field;
+  bool found = false;
+  size_t index = 0;
+  while (find_tx_extra_field_by_type(tx_extra_fields, pub_key_field, index++))
+  {
+    crypto::public_key calculated_pub_key;
+    crypto::secret_key_to_public_key(tx_key, calculated_pub_key);
+    if (calculated_pub_key == pub_key_field.pub_key)
+    {
+      found = true;
+      break;
+    }
+  }
+  THROW_WALLET_EXCEPTION_IF(!found, error::wallet_internal_error, "Given tx secret key doesn't agree with the tx public key in the blockchain");
+  tx_extra_additional_pub_keys additional_tx_pub_keys;
+  find_tx_extra_field_by_type(tx_extra_fields, additional_tx_pub_keys);
+  THROW_WALLET_EXCEPTION_IF(additional_tx_keys.size() != additional_tx_pub_keys.data.size(), error::wallet_internal_error, "The number of additional tx secret keys doesn't agree with the number of additional tx public keys in the blockchain" );
+  m_tx_keys.insert(std::make_pair(txid, tx_key));
+  m_additional_tx_keys.insert(std::make_pair(txid, additional_tx_keys));
+}
+//----------------------------------------------------------------------------------------------------
 std::string wallet2::get_spend_proof(const crypto::hash &txid, const std::string &message)
 {
   THROW_WALLET_EXCEPTION_IF(m_watch_only, error::wallet_internal_error,

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -147,7 +147,6 @@ struct options {
   const command_line::arg_descriptor<std::string> daemon_login = {"daemon-login", tools::wallet2::tr("Specify username[:password] for daemon RPC client"), "", true};
   const command_line::arg_descriptor<bool> testnet = {"testnet", tools::wallet2::tr("For testnet. Daemon must also be launched with --testnet flag"), false};
   const command_line::arg_descriptor<bool> stagenet = {"stagenet", tools::wallet2::tr("For stagenet. Daemon must also be launched with --stagenet flag"), false};
-  const command_line::arg_descriptor<bool> restricted = {"restricted-rpc", tools::wallet2::tr("Restricts to view-only commands"), false};
   const command_line::arg_descriptor<std::string, false, true, 2> shared_ringdb_dir = {
     "shared-ringdb-dir", tools::wallet2::tr("Set shared ring database path"),
     get_default_ringdb_path(),
@@ -210,7 +209,6 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   const bool testnet = command_line::get_arg(vm, opts.testnet);
   const bool stagenet = command_line::get_arg(vm, opts.stagenet);
   const network_type nettype = testnet ? TESTNET : stagenet ? STAGENET : MAINNET;
-  const bool restricted = command_line::get_arg(vm, opts.restricted);
   const uint64_t kdf_rounds = command_line::get_arg(vm, opts.kdf_rounds);
   THROW_WALLET_EXCEPTION_IF(kdf_rounds == 0, tools::error::wallet_internal_error, "KDF rounds must not be 0");
 
@@ -246,7 +244,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   if (daemon_address.empty())
     daemon_address = std::string("http://") + daemon_host + ":" + std::to_string(daemon_port);
 
-  std::unique_ptr<tools::wallet2> wallet(new tools::wallet2(nettype, restricted, kdf_rounds));
+  std::unique_ptr<tools::wallet2> wallet(new tools::wallet2(nettype, kdf_rounds));
   wallet->init(std::move(daemon_address), std::move(login));
   boost::filesystem::path ringdb_path = command_line::get_arg(vm, opts.shared_ringdb_dir);
   wallet->set_ring_database(ringdb_path.string());
@@ -658,7 +656,7 @@ const size_t MAX_SPLIT_ATTEMPTS = 30;
 constexpr const std::chrono::seconds wallet2::rpc_timeout;
 const char* wallet2::tr(const char* str) { return i18n_translate(str, "tools::wallet2"); }
 
-wallet2::wallet2(network_type nettype, bool restricted, uint64_t kdf_rounds):
+wallet2::wallet2(network_type nettype, uint64_t kdf_rounds):
   m_multisig_rescan_info(NULL),
   m_multisig_rescan_k(NULL),
   m_run(true),
@@ -689,7 +687,6 @@ wallet2::wallet2(network_type nettype, bool restricted, uint64_t kdf_rounds):
   m_segregation_height(0),
   m_ignore_fractional_outputs(true),
   m_is_initialized(false),
-  m_restricted(restricted),
   m_kdf_rounds(kdf_rounds),
   is_old_file_format(false),
   m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex),
@@ -733,7 +730,6 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.daemon_login);
   command_line::add_arg(desc_params, opts.testnet);
   command_line::add_arg(desc_params, opts.stagenet);
-  command_line::add_arg(desc_params, opts.restricted);
   command_line::add_arg(desc_params, opts.shared_ringdb_dir);
   command_line::add_arg(desc_params, opts.kdf_rounds);
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2584,7 +2584,7 @@ bool wallet2::refresh(bool trusted_daemon, uint64_t & blocks_fetched, bool& rece
   return ok;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::get_output_distribution(uint64_t &start_height, std::vector<uint64_t> &distribution)
+bool wallet2::get_rct_distribution(uint64_t &start_height, std::vector<uint64_t> &distribution)
 {
   uint32_t rpc_version;
   boost::optional<std::string> result = m_node_rpc_proxy.get_rpc_version(rpc_version);
@@ -6243,22 +6243,42 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     bool is_shortly_after_segregation_fork = height >= segregation_fork_height && height < segregation_fork_height + SEGREGATION_FORK_VICINITY;
     bool is_after_segregation_fork = height >= segregation_fork_height;
 
+    // if we have at least one rct out, get the distribution, or fall back to the previous system
+    uint64_t rct_start_height;
+    std::vector<uint64_t> rct_offsets;
+    bool has_rct = false;
+    for (size_t idx: selected_transfers)
+      if (m_transfers[idx].is_rct())
+        { has_rct = true; break; }
+    const bool has_rct_distribution = has_rct && get_rct_distribution(rct_start_height, rct_offsets);
+    if (has_rct_distribution)
+    {
+      // check we're clear enough of rct start, to avoid corner cases below
+      THROW_WALLET_EXCEPTION_IF(rct_offsets.size() <= CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE,
+          error::get_output_distribution, "Not enough rct outputs");
+    }
+
     // get histogram for the amounts we need
     cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::request req_t = AUTO_VAL_INIT(req_t);
     cryptonote::COMMAND_RPC_GET_OUTPUT_HISTOGRAM::response resp_t = AUTO_VAL_INIT(resp_t);
-    m_daemon_rpc_mutex.lock();
+    // request histogram for all outputs, except 0 if we have the rct distribution
     for(size_t idx: selected_transfers)
-      req_t.amounts.push_back(m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount());
-    std::sort(req_t.amounts.begin(), req_t.amounts.end());
-    auto end = std::unique(req_t.amounts.begin(), req_t.amounts.end());
-    req_t.amounts.resize(std::distance(req_t.amounts.begin(), end));
-    req_t.unlocked = true;
-    req_t.recent_cutoff = time(NULL) - RECENT_OUTPUT_ZONE;
-    bool r = net_utils::invoke_http_json_rpc("/json_rpc", "get_output_histogram", req_t, resp_t, m_http_client, rpc_timeout);
-    m_daemon_rpc_mutex.unlock();
-    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "transfer_selected");
-    THROW_WALLET_EXCEPTION_IF(resp_t.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_output_histogram");
-    THROW_WALLET_EXCEPTION_IF(resp_t.status != CORE_RPC_STATUS_OK, error::get_histogram_error, resp_t.status);
+      if (!m_transfers[idx].is_rct() || !has_rct_distribution)
+        req_t.amounts.push_back(m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount());
+    if (!req_t.amounts.empty())
+    {
+      std::sort(req_t.amounts.begin(), req_t.amounts.end());
+      auto end = std::unique(req_t.amounts.begin(), req_t.amounts.end());
+      req_t.amounts.resize(std::distance(req_t.amounts.begin(), end));
+      req_t.unlocked = true;
+      req_t.recent_cutoff = time(NULL) - RECENT_OUTPUT_ZONE;
+      m_daemon_rpc_mutex.lock();
+      bool r = net_utils::invoke_http_json_rpc("/json_rpc", "get_output_histogram", req_t, resp_t, m_http_client, rpc_timeout);
+      m_daemon_rpc_mutex.unlock();
+      THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "transfer_selected");
+      THROW_WALLET_EXCEPTION_IF(resp_t.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_output_histogram");
+      THROW_WALLET_EXCEPTION_IF(resp_t.status != CORE_RPC_STATUS_OK, error::get_histogram_error, resp_t.status);
+    }
 
     // if we want to segregate fake outs pre or post fork, get distribution
     std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> segregation_limit;
@@ -6314,6 +6334,36 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     COMMAND_RPC_GET_OUTPUTS_BIN::request req = AUTO_VAL_INIT(req);
     COMMAND_RPC_GET_OUTPUTS_BIN::response daemon_resp = AUTO_VAL_INIT(daemon_resp);
 
+    struct gamma_engine
+    {
+      typedef uint64_t result_type;
+      static constexpr result_type min() { return 0; }
+      static constexpr result_type max() { return std::numeric_limits<result_type>::max(); }
+      result_type operator()() { return crypto::rand<result_type>(); }
+    } engine;
+    static const double shape = 19.28/*16.94*/;
+    //static const double shape = m_testnet ? 17.02 : 17.28;
+    static const double scale = 1/1.61;
+    std::gamma_distribution<double> gamma(shape, scale);
+    auto pick_gamma = [&]()
+    {
+      double x = gamma(engine);
+      x = exp(x);
+      uint64_t block_offset = x / DIFFICULTY_TARGET_V2; // this assumes constant target over the whole rct range
+      if (block_offset >= rct_offsets.size() - 1)
+        return std::numeric_limits<uint64_t>::max(); // bad pick
+      block_offset = rct_offsets.size() - 2 - block_offset;
+      THROW_WALLET_EXCEPTION_IF(block_offset >= rct_offsets.size() - 1, error::wallet_internal_error, "Bad offset calculation");
+      THROW_WALLET_EXCEPTION_IF(rct_offsets[block_offset + 1] < rct_offsets[block_offset],
+          error::get_output_distribution, "Decreasing offsets in rct distribution: " +
+          std::to_string(block_offset) + ": " + std::to_string(rct_offsets[block_offset]) + ", " +
+          std::to_string(block_offset + 1) + ": " + std::to_string(rct_offsets[block_offset + 1]));
+      uint64_t n_rct = rct_offsets[block_offset + 1] - rct_offsets[block_offset];
+      if (n_rct == 0)
+        return rct_offsets[block_offset] ? rct_offsets[block_offset] - 1 : 0;
+      return rct_offsets[block_offset] + crypto::rand<uint64_t>() % n_rct;
+    };
+
     size_t num_selected_transfers = 0;
     for(size_t idx: selected_transfers)
     {
@@ -6324,6 +6374,7 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       // request more for rct in base recent (locked) coinbases are picked, since they're locked for longer
       size_t requested_outputs_count = base_requested_outputs_count + (td.is_rct() ? CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE : 0);
       size_t start = req.outputs.size();
+      bool use_histogram = amount != 0 || !has_rct_distribution;
 
       const bool output_is_pre_fork = td.m_block_height < segregation_fork_height;
       uint64_t num_outs = 0, num_recent_outs = 0;
@@ -6379,26 +6430,41 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
         num_post_fork_outs = num_outs - segregation_limit[amount].first;
       }
 
-      LOG_PRINT_L1("" << num_outs << " unlocked outputs of size " << print_money(amount));
-      THROW_WALLET_EXCEPTION_IF(num_outs == 0, error::wallet_internal_error,
-          "histogram reports no unlocked outputs for " + boost::lexical_cast<std::string>(amount) + ", not even ours");
-      THROW_WALLET_EXCEPTION_IF(num_recent_outs > num_outs, error::wallet_internal_error,
-          "histogram reports more recent outs than outs for " + boost::lexical_cast<std::string>(amount));
+      if (use_histogram)
+      {
+        LOG_PRINT_L1("" << num_outs << " unlocked outputs of size " << print_money(amount));
+        THROW_WALLET_EXCEPTION_IF(num_outs == 0, error::wallet_internal_error,
+            "histogram reports no unlocked outputs for " + boost::lexical_cast<std::string>(amount) + ", not even ours");
+        THROW_WALLET_EXCEPTION_IF(num_recent_outs > num_outs, error::wallet_internal_error,
+            "histogram reports more recent outs than outs for " + boost::lexical_cast<std::string>(amount));
+      }
+      else
+      {
+        // the base offset of the first rct output in the first unlocked block (or the one to be if there's none)
+        num_outs = rct_offsets[rct_offsets.size() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE];
+        LOG_PRINT_L1("" << num_outs << " unlocked rct outputs");
+        THROW_WALLET_EXCEPTION_IF(num_outs == 0, error::wallet_internal_error,
+            "histogram reports no unlocked rct outputs, not even ours");
+      }
 
-      // how many fake outs to draw on a pre-fork triangular distribution
+      // how many fake outs to draw on a pre-fork distribution
       size_t pre_fork_outputs_count = requested_outputs_count * pre_fork_num_out_ratio;
       size_t post_fork_outputs_count = requested_outputs_count * post_fork_num_out_ratio;
       // how many fake outs to draw otherwise
       size_t normal_output_count = requested_outputs_count - pre_fork_outputs_count - post_fork_outputs_count;
 
-      // X% of those outs are to be taken from recent outputs
-      size_t recent_outputs_count = normal_output_count * RECENT_OUTPUT_RATIO;
-      if (recent_outputs_count == 0)
-        recent_outputs_count = 1; // ensure we have at least one, if possible
-      if (recent_outputs_count > num_recent_outs)
-        recent_outputs_count = num_recent_outs;
-      if (td.m_global_output_index >= num_outs - num_recent_outs && recent_outputs_count > 0)
-        --recent_outputs_count; // if the real out is recent, pick one less recent fake out
+      size_t recent_outputs_count = 0;
+      if (use_histogram)
+      {
+        // X% of those outs are to be taken from recent outputs
+        recent_outputs_count = normal_output_count * RECENT_OUTPUT_RATIO;
+        if (recent_outputs_count == 0)
+          recent_outputs_count = 1; // ensure we have at least one, if possible
+        if (recent_outputs_count > num_recent_outs)
+          recent_outputs_count = num_recent_outs;
+        if (td.m_global_output_index >= num_outs - num_recent_outs && recent_outputs_count > 0)
+          --recent_outputs_count; // if the real out is recent, pick one less recent fake out
+      }
       LOG_PRINT_L1("Fake output makeup: " << requested_outputs_count << " requested: " << recent_outputs_count << " recent, " <<
           pre_fork_outputs_count << " pre-fork, " << post_fork_outputs_count << " post-fork, " <<
           (requested_outputs_count - recent_outputs_count - pre_fork_outputs_count - post_fork_outputs_count) << " full-chain");
@@ -6478,7 +6544,26 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
 
           uint64_t i;
           const char *type = "";
-          if (num_found - 1 < recent_outputs_count) // -1 to account for the real one we seeded with
+          if (amount == 0 && has_rct_distribution)
+          {
+            // gamma distribution
+            if (num_found -1 < recent_outputs_count + pre_fork_outputs_count)
+            {
+              do i = pick_gamma(); while (i >= segregation_limit[amount].first);
+              type = "pre-fork gamma";
+            }
+            else if (num_found -1 < recent_outputs_count + pre_fork_outputs_count + post_fork_outputs_count)
+            {
+              do i = pick_gamma(); while (i < segregation_limit[amount].first || i >= num_outs);
+              type = "post-fork gamma";
+            }
+            else
+            {
+              do i = pick_gamma(); while (i >= num_outs);
+              type = "gamma";
+            }
+          }
+          else if (num_found - 1 < recent_outputs_count) // -1 to account for the real one we seeded with
           {
             // triangular distribution over [a,b) with a=0, mode c=b=up_index_limit
             uint64_t r = crypto::rand<uint64_t>() % ((uint64_t)1 << 53);
@@ -6543,7 +6628,7 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
 
     // get the keys for those
     m_daemon_rpc_mutex.lock();
-    r = epee::net_utils::invoke_http_bin("/get_outs.bin", req, daemon_resp, m_http_client, rpc_timeout);
+    bool r = epee::net_utils::invoke_http_bin("/get_outs.bin", req, daemon_resp, m_http_client, rpc_timeout);
     m_daemon_rpc_mutex.unlock();
     THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_outs.bin");
     THROW_WALLET_EXCEPTION_IF(daemon_resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "get_outs.bin");

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10260,11 +10260,10 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
     {
       const transfer_details& td = m_transfers[n];
       confirmed_transfer_details pd;
-      pd.m_change = (uint64_t)-1;                             // cahnge is unknown
+      pd.m_change = (uint64_t)-1;                             // change is unknown
       pd.m_amount_in = pd.m_amount_out = td.amount();         // fee is unknown
-      std::string err;
-      pd.m_block_height = get_daemon_blockchain_height(err);  // spent block height is unknown, so hypothetically set to the highest
-      crypto::hash spent_txid = crypto::rand<crypto::hash>(); // spent txid is unknown, so hypothetically set to random
+      pd.m_block_height = 0;  // spent block height is unknown
+      const crypto::hash &spent_txid = crypto::null_hash; // spent txid is unknown
       m_confirmed_txs.insert(std::make_pair(spent_txid, pd));
     }
   }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10376,18 +10376,20 @@ size_t wallet2::import_outputs(const std::vector<tools::wallet2::transfer_detail
     crypto::public_key tx_pub_key = get_tx_pub_key_from_received_outs(td);
     const std::vector<crypto::public_key> additional_tx_pub_keys = get_additional_tx_pub_keys_from_extra(td.m_tx);
 
+    THROW_WALLET_EXCEPTION_IF(td.m_tx.vout[td.m_internal_output_index].target.type() != typeid(cryptonote::txout_to_key),
+        error::wallet_internal_error, "Unsupported output type");
     const crypto::public_key& out_key = boost::get<cryptonote::txout_to_key>(td.m_tx.vout[td.m_internal_output_index].target).key;
     bool r = cryptonote::generate_key_image_helper(m_account.get_keys(), m_subaddresses, out_key, tx_pub_key, additional_tx_pub_keys, td.m_internal_output_index, in_ephemeral, td.m_key_image, m_account.get_device());
     THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, "Failed to generate key image");
     expand_subaddresses(td.m_subaddr_index);
     td.m_key_image_known = true;
     td.m_key_image_partial = false;
-    THROW_WALLET_EXCEPTION_IF(in_ephemeral.pub != boost::get<cryptonote::txout_to_key>(td.m_tx.vout[td.m_internal_output_index].target).key,
+    THROW_WALLET_EXCEPTION_IF(in_ephemeral.pub != out_key,
         error::wallet_internal_error, "key_image generated ephemeral public key not matched with output_key at index " + boost::lexical_cast<std::string>(i));
 
     m_key_images[td.m_key_image] = m_transfers.size();
     m_pub_keys[td.get_public_key()] = m_transfers.size();
-    m_transfers.push_back(td);
+    m_transfers.push_back(std::move(td));
   }
 
   return m_transfers.size();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11272,6 +11272,7 @@ std::vector<std::pair<uint64_t, uint64_t>> wallet2::estimate_backlog(const std::
   const auto result = m_node_rpc_proxy.get_block_size_limit(block_size_limit);
   throw_on_rpc_response_error(result, "get_info");
   uint64_t full_reward_zone = block_size_limit / 2;
+  THROW_WALLET_EXCEPTION_IF(full_reward_zone == 0, error::wallet_internal_error, "Invalid block size limit from daemon");
 
   std::vector<std::pair<uint64_t, uint64_t>> blocks;
   for (const auto &fee_level: fee_levels)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1636,6 +1636,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       payment.m_block_height = height;
       payment.m_unlock_time  = tx.unlock_time;
       payment.m_timestamp    = ts;
+      payment.m_coinbase     = miner_tx;
       payment.m_subaddr_index = i.first;
       if (pool) {
         emplace_or_replace(m_unconfirmed_payments, payment_id, pool_payment_details{payment, double_spend_seen});
@@ -7593,6 +7594,7 @@ void wallet2::light_wallet_get_address_txs()
       payment.m_block_height = t.height;
       payment.m_unlock_time  = t.unlock_time;
       payment.m_timestamp = t.timestamp;
+      payment.m_coinbase = t.coinbase;
         
       if (t.mempool) {   
         if (std::find(unconfirmed_payments_txs.begin(), unconfirmed_payments_txs.end(), tx_hash) == unconfirmed_payments_txs.end()) {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10058,6 +10058,17 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
   std::unordered_set<crypto::hash> spent_txids;   // For each spent key image, search for a tx in m_transfers that uses it as input.
   std::vector<size_t> swept_transfers;            // If such a spending tx wasn't found in m_transfers, this means the spending tx 
                                                   // was created by sweep_all, so we can't know the spent height and other detailed info.
+  std::unordered_map<crypto::key_image, crypto::hash> spent_key_images;
+
+  for (const transfer_details &td: m_transfers)
+  {
+    for (const cryptonote::txin_v& in : td.m_tx.vin)
+    {
+      if (in.type() == typeid(cryptonote::txin_to_key))
+        spent_key_images.insert(std::make_pair(boost::get<cryptonote::txin_to_key>(in).k_image, td.m_txid));
+    }
+  }
+
   for(size_t i = 0; i < signed_key_images.size(); ++i)
   {
     transfer_details &td = m_transfers[i];
@@ -10071,28 +10082,11 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
 
     if (i < daemon_resp.spent_status.size() && daemon_resp.spent_status[i] == COMMAND_RPC_IS_KEY_IMAGE_SPENT::SPENT_IN_BLOCKCHAIN)
     {
-      bool is_spent_tx_found = false;
-      for (auto it = m_transfers.rbegin(); &(*it) != &td; ++it)
-      {
-        bool is_spent_tx = false;
-        for(const cryptonote::txin_v& in : it->m_tx.vin)
-        {
-          if(in.type() == typeid(cryptonote::txin_to_key) && td.m_key_image == boost::get<cryptonote::txin_to_key>(in).k_image)
-          {
-            is_spent_tx = true;
-            break;
-          }
-        }
-        if (is_spent_tx)
-        {
-          is_spent_tx_found = true;
-          spent_txids.insert(it->m_txid);
-          break;
-        }
-      }
-
-      if (!is_spent_tx_found)
+      const std::unordered_map<crypto::key_image, crypto::hash>::const_iterator skii = spent_key_images.find(td.m_key_image);
+      if (skii == spent_key_images.end())
         swept_transfers.push_back(i);
+      else
+        spent_txids.insert(skii->second);
     }
   }
   MDEBUG("Total: " << print_money(spent) << " spent, " << print_money(unspent) << " unspent");

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -912,6 +912,14 @@ cryptonote::account_public_address wallet2::get_subaddress(const cryptonote::sub
   return hwdev.get_subaddress(m_account.get_keys(), index);
 }
 //----------------------------------------------------------------------------------------------------
+boost::optional<cryptonote::subaddress_index> wallet2::get_subaddress_index(const cryptonote::account_public_address& address) const
+{
+  auto index = m_subaddresses.find(address.m_spend_public_key);
+  if (index == m_subaddresses.end())
+    return boost::none;
+  return index->second;
+}
+//----------------------------------------------------------------------------------------------------
 crypto::public_key wallet2::get_subaddress_spend_public_key(const cryptonote::subaddress_index& index) const
 {
   hw::device &hwdev = m_account.get_device();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7867,6 +7867,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   // early out if we know we can't make it anyway
   // we could also check for being within FEE_PER_KB, but if the fee calculation
   // ever changes, this might be missed, so let this go through
+  const uint64_t min_fee = (fee_multiplier * fee_per_kb * estimate_tx_size(use_rct, 1, fake_outs_count, 2, extra.size(), bulletproof)) / 1024;
   uint64_t balance_subtotal = 0;
   uint64_t unlocked_balance_subtotal = 0;
   for (uint32_t index_minor : subaddr_indices)
@@ -7874,10 +7875,10 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
     balance_subtotal += balance_per_subaddr[index_minor];
     unlocked_balance_subtotal += unlocked_balance_per_subaddr[index_minor];
   }
-  THROW_WALLET_EXCEPTION_IF(needed_money > balance_subtotal, error::not_enough_money,
+  THROW_WALLET_EXCEPTION_IF(needed_money + min_fee > balance_subtotal, error::not_enough_money,
     balance_subtotal, needed_money, 0);
   // first check overall balance is enough, then unlocked one, so we throw distinct exceptions
-  THROW_WALLET_EXCEPTION_IF(needed_money > unlocked_balance_subtotal, error::not_enough_unlocked_money,
+  THROW_WALLET_EXCEPTION_IF(needed_money + min_fee > unlocked_balance_subtotal, error::not_enough_unlocked_money,
       unlocked_balance_subtotal, needed_money, 0);
 
   for (uint32_t i : subaddr_indices)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -89,6 +89,7 @@ using namespace cryptonote;
 
 // arbitrary, used to generate different hashes from the same input
 #define CHACHA8_KEY_TAIL 0x8c
+#define CACHE_KEY_TAIL 0x8d
 
 #define UNSIGNED_TX_PREFIX "Aeon unsigned tx set\004"
 #define SIGNED_TX_PREFIX "Aeon signed tx set\004"
@@ -120,8 +121,6 @@ using namespace cryptonote;
 #define FIRST_REFRESH_GRANULARITY     1024
 
 static const std::string MULTISIG_SIGNATURE_MAGIC = "SigMultisigPkV1";
-
-std::atomic<unsigned int> tools::wallet2::key_ref::refs(0);
 
 namespace
 {
@@ -204,7 +203,7 @@ std::string get_size_string(const cryptonote::blobdata &tx)
   return get_size_string(tx.size());
 }
 
-std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variables_map& vm, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variables_map& vm, bool rpc, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
 {
   const bool testnet = command_line::get_arg(vm, opts.testnet);
   const bool stagenet = command_line::get_arg(vm, opts.stagenet);
@@ -245,7 +244,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
     daemon_address = std::string("http://") + daemon_host + ":" + std::to_string(daemon_port);
 
   std::unique_ptr<tools::wallet2> wallet(new tools::wallet2(nettype, kdf_rounds));
-  wallet->init(std::move(daemon_address), std::move(login));
+  wallet->init(rpc, std::move(daemon_address), std::move(login));
   boost::filesystem::path ringdb_path = command_line::get_arg(vm, opts.shared_ringdb_dir);
   wallet->set_ring_database(ringdb_path.string());
   return wallet;
@@ -280,7 +279,7 @@ boost::optional<tools::password_container> get_password(const boost::program_opt
   return password_prompter(verify ? tr("Enter a new password for the wallet") : tr("Wallet password"), verify);
 }
 
-std::unique_ptr<tools::wallet2> generate_from_json(const std::string& json_file, const boost::program_options::variables_map& vm, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+std::unique_ptr<tools::wallet2> generate_from_json(const std::string& json_file, const boost::program_options::variables_map& vm, bool rpc, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
 {
   const bool testnet = command_line::get_arg(vm, opts.testnet);
   const bool stagenet = command_line::get_arg(vm, opts.stagenet);
@@ -418,7 +417,7 @@ std::unique_ptr<tools::wallet2> generate_from_json(const std::string& json_file,
     THROW_WALLET_EXCEPTION_IF(deprecated_wallet, tools::error::wallet_internal_error,
       tools::wallet2::tr("Cannot generate deprecated wallets from JSON"));
 
-    wallet.reset(make_basic(vm, opts, password_prompter).release());
+    wallet.reset(make_basic(vm, rpc, opts, password_prompter).release());
     wallet->set_refresh_from_block_height(field_scan_from_height);
     wallet->explicit_refresh_from_block_height(field_scan_from_height_found);
 
@@ -656,6 +655,34 @@ const size_t MAX_SPLIT_ATTEMPTS = 30;
 constexpr const std::chrono::seconds wallet2::rpc_timeout;
 const char* wallet2::tr(const char* str) { return i18n_translate(str, "tools::wallet2"); }
 
+wallet_keys_unlocker::wallet_keys_unlocker(wallet2 &w, const boost::optional<tools::password_container> &password):
+  w(w),
+  locked(password != boost::none)
+{
+  if (!locked || w.is_rpc())
+    return;
+  const epee::wipeable_string pass = password->password();
+  w.generate_chacha_key_from_password(pass, key);
+  w.decrypt_keys(key);
+}
+
+wallet_keys_unlocker::wallet_keys_unlocker(wallet2 &w, bool locked, const epee::wipeable_string &password):
+  w(w),
+  locked(locked)
+{
+  if (!locked)
+    return;
+  w.generate_chacha_key_from_password(password, key);
+  w.decrypt_keys(key);
+}
+
+wallet_keys_unlocker::~wallet_keys_unlocker()
+{
+  if (!locked)
+    return;
+  w.encrypt_keys(key);
+}
+
 wallet2::wallet2(network_type nettype, uint64_t kdf_rounds):
   m_multisig_rescan_info(NULL),
   m_multisig_rescan_k(NULL),
@@ -701,7 +728,9 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds):
   m_key_on_device(false),
   m_ring_history_saved(false),
   m_ringdb(),
-  m_last_block_reward(0)
+  m_last_block_reward(0),
+  m_encrypt_keys_after_refresh(boost::none),
+  m_rpc(false)
 {
 }
 
@@ -734,14 +763,14 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.kdf_rounds);
 }
 
-std::unique_ptr<wallet2> wallet2::make_from_json(const boost::program_options::variables_map& vm, const std::string& json_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+std::unique_ptr<wallet2> wallet2::make_from_json(const boost::program_options::variables_map& vm, bool rpc, const std::string& json_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
 {
   const options opts{};
-  return generate_from_json(json_file, vm, opts, password_prompter);
+  return generate_from_json(json_file, vm, rpc, opts, password_prompter);
 }
 
 std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
-  const boost::program_options::variables_map& vm, const std::string& wallet_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+  const boost::program_options::variables_map& vm, bool rpc, const std::string& wallet_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
 {
   const options opts{};
   auto pwd = get_password(vm, opts, password_prompter, false);
@@ -749,7 +778,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
   {
     return {nullptr, password_container{}};
   }
-  auto wallet = make_basic(vm, opts, password_prompter);
+  auto wallet = make_basic(vm, rpc, opts, password_prompter);
   if (wallet)
   {
     wallet->load(wallet_file, pwd->password());
@@ -757,7 +786,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
   return {std::move(wallet), std::move(*pwd)};
 }
 
-std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const boost::program_options::variables_map& vm, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter)
+std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const boost::program_options::variables_map& vm, bool rpc, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter)
 {
   const options opts{};
   auto pwd = get_password(vm, opts, password_prompter, true);
@@ -765,18 +794,19 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const 
   {
     return {nullptr, password_container{}};
   }
-  return {make_basic(vm, opts, password_prompter), std::move(*pwd)};
+  return {make_basic(vm, rpc, opts, password_prompter), std::move(*pwd)};
 }
 
-std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::variables_map& vm, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::variables_map& vm, bool rpc, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
 {
   const options opts{};
-  return make_basic(vm, opts, password_prompter);
+  return make_basic(vm, rpc, opts, password_prompter);
 }
 
 //----------------------------------------------------------------------------------------------------
-bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_size_limit, bool ssl)
+bool wallet2::init(bool rpc, std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_size_limit, bool ssl)
 {
+  m_rpc = rpc;
   m_checkpoints.init_default_checkpoints(m_nettype);
   if(m_http_client.is_connected())
     m_http_client.disconnect();
@@ -793,8 +823,7 @@ bool wallet2::is_deterministic() const
   crypto::secret_key second;
   keccak((uint8_t *)&get_account().get_keys().m_spend_secret_key, sizeof(crypto::secret_key), (uint8_t *)&second, sizeof(crypto::secret_key));
   sc_reduce32((uint8_t *)&second);
-  bool keys_deterministic = memcmp(second.data,get_account().get_keys().m_view_secret_key.data, sizeof(crypto::secret_key)) == 0;
-  return keys_deterministic;
+  return memcmp(second.data,get_account().get_keys().m_view_secret_key.data, sizeof(crypto::secret_key)) == 0;
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::get_seed(epee::wipeable_string& electrum_words, const epee::wipeable_string &passphrase) const
@@ -1111,9 +1140,25 @@ static uint64_t decodeRct(const rct::rctSig & rv, const crypto::key_derivation &
   }
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::scan_output(const cryptonote::transaction &tx, bool miner_tx, const crypto::public_key &tx_pub_key, size_t i, tx_scan_info_t &tx_scan_info, int &num_vouts_received, std::unordered_map<cryptonote::subaddress_index, uint64_t> &tx_money_got_in_outs, std::vector<size_t> &outs) const
+void wallet2::scan_output(const cryptonote::transaction &tx, bool miner_tx, const crypto::public_key &tx_pub_key, size_t i, tx_scan_info_t &tx_scan_info, int &num_vouts_received, std::unordered_map<cryptonote::subaddress_index, uint64_t> &tx_money_got_in_outs, std::vector<size_t> &outs)
 {
   THROW_WALLET_EXCEPTION_IF(i >= tx.vout.size(), error::wallet_internal_error, "Invalid vout index");
+
+  // if keys are encrypted, ask for password
+  if (m_ask_password && !m_rpc && !m_watch_only && !m_multisig_rescan_k)
+  {
+    static critical_section password_lock;
+    CRITICAL_REGION_LOCAL(password_lock);
+    if (!m_encrypt_keys_after_refresh)
+    {
+      boost::optional<epee::wipeable_string> pwd = m_callback->on_get_password("output received");
+      THROW_WALLET_EXCEPTION_IF(!pwd, error::password_needed, tr("Password is needed to compute key image for incoming aeon"));
+      THROW_WALLET_EXCEPTION_IF(!verify_password(*pwd), error::password_needed, tr("Invalid password: password is needed to compute key image for incoming aeon"));
+      decrypt_keys(*pwd);
+      m_encrypt_keys_after_refresh = *pwd;
+    }
+  }
+
   if (m_multisig)
   {
     tx_scan_info.in_ephemeral.pub = boost::get<cryptonote::txout_to_key>(tx.vout[i].target).key;
@@ -2100,6 +2145,14 @@ void wallet2::update_pool_state(bool refreshed)
 {
   MDEBUG("update_pool_state start");
 
+  auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {
+    if (m_encrypt_keys_after_refresh)
+    {
+      encrypt_keys(*m_encrypt_keys_after_refresh);
+      m_encrypt_keys_after_refresh = boost::none;
+    }
+  });
+
   // get the pool state
   cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::request req;
   cryptonote::COMMAND_RPC_GET_TRANSACTION_POOL_HASHES_BIN::response res;
@@ -2406,8 +2459,6 @@ bool wallet2::delete_address_book_row(std::size_t row_id) {
 //----------------------------------------------------------------------------------------------------
 void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blocks_fetched, bool& received_money)
 {
-  key_ref kref(*this);
-
   if(m_light_wallet) {
 
     // MyMonero get_address_info needs to be called occasionally to trigger wallet sync.
@@ -2474,6 +2525,14 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
   // always reset start_height to 0 to force short_chain_ history to be used on
   // subsequent pulls in this refresh.
   start_height = 0;
+
+  auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {
+    if (m_encrypt_keys_after_refresh)
+    {
+      encrypt_keys(*m_encrypt_keys_after_refresh);
+      m_encrypt_keys_after_refresh = boost::none;
+    }
+  });
 
   bool first = true;
   while(m_run.load(std::memory_order_relaxed))
@@ -2543,6 +2602,12 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
       {
         throw std::runtime_error("proxy exception in refresh thread");
       }
+    }
+    catch (const tools::error::password_needed&)
+    {
+      blocks_fetched += added_blocks;
+      waiter.wait(&tpool);
+      throw;
     }
     catch (const std::exception&)
     {
@@ -2765,8 +2830,20 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
   std::string multisig_signers;
   cryptonote::account_base account = m_account;
 
+  crypto::chacha_key key;
+  crypto::generate_chacha_key(password.data(), password.size(), key, m_kdf_rounds);
+
+  if (m_ask_password && !m_rpc && !m_watch_only)
+  {
+    account.encrypt_viewkey(key);
+    account.decrypt_keys(key);
+  }
+
   if (watch_only)
     account.forget_spend_key();
+
+  account.encrypt_keys(key);
+
   bool r = epee::serialization::store_t_to_binary(account, account_data);
   CHECK_AND_ASSERT_MES(r, false, "failed to serialize wallet keys");
   wallet2::keys_file_data keys_file_data = boost::value_initialized<wallet2::keys_file_data>();
@@ -2883,6 +2960,9 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
   value2.SetUint(m_subaddress_lookahead_minor);
   json.AddMember("subaddress_lookahead_minor", value2, json.GetAllocator());
 
+  value2.SetUint(1);
+  json.AddMember("encrypted_secret_keys", value2, json.GetAllocator());
+
   // Serialize the JSON object
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
@@ -2890,7 +2970,6 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
   account_data = buffer.GetString();
 
   // Encrypt the entire JSON object.
-  crypto::chacha_key key;
   crypto::generate_chacha_key(password.data(), password.size(), key, m_kdf_rounds);
   std::string cipher;
   cipher.resize(account_data.size());
@@ -2908,6 +2987,35 @@ bool wallet2::store_keys(const std::string& keys_file_name, const epee::wipeable
   return true;
 }
 //----------------------------------------------------------------------------------------------------
+void wallet2::setup_keys(const epee::wipeable_string &password)
+{
+  crypto::chacha_key key;
+  crypto::generate_chacha_key(password.data(), password.size(), key, m_kdf_rounds);
+
+  // re-encrypt, but keep viewkey unencrypted
+  if (m_ask_password && !m_rpc && !m_watch_only)
+  {
+    m_account.encrypt_keys(key);
+    m_account.decrypt_viewkey(key);
+  }
+
+  static_assert(HASH_SIZE == sizeof(crypto::chacha_key), "Mismatched sizes of hash and chacha key");
+  tools::scrubbed_arr<char, HASH_SIZE+1> cache_key_data;
+  memcpy(cache_key_data.data(), &key, HASH_SIZE);
+  cache_key_data[HASH_SIZE] = CACHE_KEY_TAIL;
+  cn_fast_hash(cache_key_data.data(), HASH_SIZE+1, (crypto::hash&)m_cache_key);
+  get_ringdb_key();
+}
+//----------------------------------------------------------------------------------------------------
+void wallet2::change_password(const std::string &filename, const epee::wipeable_string &original_password, const epee::wipeable_string &new_password)
+{
+  if (m_ask_password && !m_rpc && !m_watch_only)
+    decrypt_keys(original_password);
+  setup_keys(new_password);
+  rewrite(filename, new_password);
+  store();
+}
+//----------------------------------------------------------------------------------------------------
 /*!
  * \brief Load wallet information from wallet file.
  * \param keys_file_name Name of wallet file
@@ -2918,6 +3026,7 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
   rapidjson::Document json;
   wallet2::keys_file_data keys_file_data;
   std::string buf;
+  bool encrypted_secret_keys = false;
   bool r = epee::file_io_utils::load_file_to_string(keys_file_name, buf);
   THROW_WALLET_EXCEPTION_IF(!r, error::file_read_error, keys_file_name);
 
@@ -2963,6 +3072,7 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
     m_subaddress_lookahead_major = SUBADDRESS_LOOKAHEAD_MAJOR;
     m_subaddress_lookahead_minor = SUBADDRESS_LOOKAHEAD_MINOR;
     m_key_on_device = false;
+    encrypted_secret_keys = false;
   }
   else if(json.IsObject())
   {
@@ -3092,6 +3202,8 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
     m_subaddress_lookahead_major = field_subaddress_lookahead_major;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, subaddress_lookahead_minor, uint32_t, Uint, false, SUBADDRESS_LOOKAHEAD_MINOR);
     m_subaddress_lookahead_minor = field_subaddress_lookahead_minor;
+    GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, encrypted_secret_keys, uint32_t, Uint, false, false);
+    encrypted_secret_keys = field_encrypted_secret_keys;
   }
   else
   {
@@ -3108,12 +3220,39 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
     m_account.set_device(hwdev);
     LOG_PRINT_L0("Device inited...");
   }
+
+  if (r)
+  {
+    if (encrypted_secret_keys)
+    {
+      m_account.decrypt_keys(key);
+    }
+    else
+    {
+      // rewrite with encrypted keys, ignore errors
+      if (m_ask_password && !m_rpc && !m_watch_only)
+        encrypt_keys(key);
+      bool saved_ret = store_keys(keys_file_name, password, m_watch_only);
+      if (!saved_ret)
+      {
+        // just moan a bit, but not fatal
+        MERROR("Error saving keys file with encrypted keys, not fatal");
+      }
+      if (m_ask_password && !m_rpc && !m_watch_only)
+        decrypt_keys(key);
+      m_keys_file_locker.reset();
+    }
+  }
   const cryptonote::account_keys& keys = m_account.get_keys();
   hw::device &hwdev = m_account.get_device();
   r = r && hwdev.verify_keys(keys.m_view_secret_key,  keys.m_account_address.m_view_public_key);
   if(!m_watch_only && !m_multisig)
     r = r && hwdev.verify_keys(keys.m_spend_secret_key, keys.m_account_address.m_spend_public_key);
   THROW_WALLET_EXCEPTION_IF(!r, error::invalid_password);
+
+  if (r)
+    setup_keys(password);
+
   return true;
 }
 
@@ -3154,6 +3293,7 @@ bool wallet2::verify_password(const std::string& keys_file_name, const epee::wip
   rapidjson::Document json;
   wallet2::keys_file_data keys_file_data;
   std::string buf;
+  bool encrypted_secret_keys = false;
   bool r = epee::file_io_utils::load_file_to_string(keys_file_name, buf);
   THROW_WALLET_EXCEPTION_IF(!r, error::file_read_error, keys_file_name);
 
@@ -3177,17 +3317,48 @@ bool wallet2::verify_password(const std::string& keys_file_name, const epee::wip
   {
     account_data = std::string(json["key_data"].GetString(), json["key_data"].GetString() +
       json["key_data"].GetStringLength());
+    GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, encrypted_secret_keys, uint32_t, Uint, false, false);
+    encrypted_secret_keys = field_encrypted_secret_keys;
   }
 
   cryptonote::account_base account_data_check;
 
   r = epee::serialization::load_t_from_binary(account_data_check, account_data);
-  const cryptonote::account_keys& keys = account_data_check.get_keys();
 
+  if (encrypted_secret_keys)
+    account_data_check.decrypt_keys(key);
+
+  const cryptonote::account_keys& keys = account_data_check.get_keys();
   r = r && hwdev.verify_keys(keys.m_view_secret_key,  keys.m_account_address.m_view_public_key);
   if(!no_spend_key)
     r = r && hwdev.verify_keys(keys.m_spend_secret_key, keys.m_account_address.m_spend_public_key);
   return r;
+}
+
+void wallet2::encrypt_keys(const crypto::chacha_key &key)
+{
+  m_account.encrypt_keys(key);
+  m_account.decrypt_viewkey(key);
+}
+
+void wallet2::decrypt_keys(const crypto::chacha_key &key)
+{
+  m_account.encrypt_viewkey(key);
+  m_account.decrypt_keys(key);
+}
+
+void wallet2::encrypt_keys(const epee::wipeable_string &password)
+{
+  crypto::chacha_key key;
+  crypto::generate_chacha_key(password.data(), password.size(), key, m_kdf_rounds);
+  encrypt_keys(key);
+}
+
+void wallet2::decrypt_keys(const epee::wipeable_string &password)
+{
+  crypto::chacha_key key;
+  crypto::generate_chacha_key(password.data(), password.size(), key, m_kdf_rounds);
+  decrypt_keys(key);
 }
 
 /*!
@@ -3264,6 +3435,7 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   m_multisig_threshold = threshold;
   m_multisig_signers = multisig_signers;
   m_key_on_device = false;
+  setup_keys(password);
 
   if (!wallet_.empty())
   {
@@ -3318,6 +3490,7 @@ crypto::secret_key wallet2::generate(const std::string& wallet_, const epee::wip
   m_multisig_threshold = 0;
   m_multisig_signers.clear();
   m_key_on_device = false;
+  setup_keys(password);
 
   // calculate a starting refresh height
   if(m_refresh_from_block_height == 0 && !recover){
@@ -3419,6 +3592,7 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   m_multisig_threshold = 0;
   m_multisig_signers.clear();
   m_key_on_device = false;
+  setup_keys(password);
 
   if (!wallet_.empty())
   {
@@ -3472,6 +3646,7 @@ void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& 
   m_multisig_threshold = 0;
   m_multisig_signers.clear();
   m_key_on_device = false;
+  setup_keys(password);
 
   if (!wallet_.empty())
   {
@@ -3518,6 +3693,7 @@ void wallet2::restore(const std::string& wallet_, const epee::wipeable_string& p
   m_multisig = false;
   m_multisig_threshold = 0;
   m_multisig_signers.clear();
+  setup_keys(password);
 
   if (!wallet_.empty()) {
     bool r = store_keys(m_keys_file, password, false);
@@ -3556,6 +3732,17 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
   crypto::hash hash;
 
   clear();
+
+  // decrypt keys
+  epee::misc_utils::auto_scope_leave_caller keys_reencryptor;
+  if (m_ask_password && !m_rpc && !m_watch_only)
+  {
+    crypto::chacha_key chacha_key;
+    crypto::generate_chacha_key(password.data(), password.size(), chacha_key, m_kdf_rounds);
+    m_account.encrypt_viewkey(chacha_key);
+    m_account.decrypt_keys(chacha_key);
+    keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this, chacha_key]() { m_account.encrypt_keys(chacha_key); m_account.decrypt_viewkey(chacha_key); });
+  }
 
   MINFO("Creating spend key...");
   std::vector<crypto::secret_key> multisig_keys;
@@ -3616,6 +3803,9 @@ std::string wallet2::make_multisig(const epee::wipeable_string &password,
   {
     m_multisig_signers = std::vector<crypto::public_key>(spend_keys.size() + 1, crypto::null_pkey);
   }
+
+  // re-encrypt keys
+  keys_reencryptor = epee::misc_utils::auto_scope_leave_caller();
 
   if (!m_wallet_file.empty())
   {
@@ -3699,6 +3889,17 @@ bool wallet2::finalize_multisig(const epee::wipeable_string &password, std::unor
 {
   CHECK_AND_ASSERT_THROW_MES(!pkeys.empty(), "empty pkeys");
 
+  // keys are decrypted
+  epee::misc_utils::auto_scope_leave_caller keys_reencryptor;
+  if (m_ask_password && !m_rpc && !m_watch_only)
+  {
+    crypto::chacha_key chacha_key;
+    crypto::generate_chacha_key(password.data(), password.size(), chacha_key, m_kdf_rounds);
+    m_account.encrypt_viewkey(chacha_key);
+    m_account.decrypt_keys(chacha_key);
+    keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this, chacha_key]() { m_account.encrypt_keys(chacha_key); m_account.decrypt_viewkey(chacha_key); });
+  }
+
   // add ours if not included
   crypto::public_key local_signer;
   CHECK_AND_ASSERT_THROW_MES(crypto::secret_key_to_public_key(get_account().get_keys().m_spend_secret_key, local_signer),
@@ -3720,6 +3921,9 @@ bool wallet2::finalize_multisig(const epee::wipeable_string &password, std::unor
 
   m_multisig_signers = signers;
   std::sort(m_multisig_signers.begin(), m_multisig_signers.end(), [](const crypto::public_key &e0, const crypto::public_key &e1){ return memcmp(&e0, &e1, sizeof(e0)); });
+
+  // keys are encrypted again
+  keys_reencryptor = epee::misc_utils::auto_scope_leave_caller();
 
   if (!m_wallet_file.empty())
   {
@@ -4032,6 +4236,11 @@ bool wallet2::generate_chacha_key_from_secret_keys(crypto::chacha_key &key) cons
   return hwdev.generate_chacha_key(m_account.get_keys(), key, m_kdf_rounds);
 }
 //----------------------------------------------------------------------------------------------------
+void wallet2::generate_chacha_key_from_password(const epee::wipeable_string &pass, crypto::chacha_key &key) const
+{
+  crypto::generate_chacha_key(pass.data(), pass.size(), key, m_kdf_rounds);
+}
+//----------------------------------------------------------------------------------------------------
 void wallet2::load(const std::string& wallet_, const epee::wipeable_string& password)
 {
   clear();
@@ -4051,6 +4260,8 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
   }
   LOG_PRINT_L0("Loaded wallet keys file, with public address: " << m_account.get_public_address_str(m_nettype));
   lock_keys_file();
+
+  wallet_keys_unlocker unlocker(*this, m_ask_password && !m_rpc && !m_watch_only, password);
 
   //keys loaded ok!
   //try to load wallet file. but even if we failed, it is not big problem
@@ -4073,11 +4284,9 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
 
       r = ::serialization::parse_binary(buf, cache_file_data);
       THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, "internal error: failed to deserialize \"" + m_wallet_file + '\"');
-      crypto::chacha_key key;
-      generate_chacha_key_from_secret_keys(key);
       std::string cache_data;
       cache_data.resize(cache_file_data.cache_data.size());
-      crypto::chacha20(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), key, cache_file_data.iv, &cache_data[0]);
+      crypto::chacha20(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), m_cache_key, cache_file_data.iv, &cache_data[0]);
 
       try {
         std::stringstream iss;
@@ -4085,11 +4294,13 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
         boost::archive::portable_binary_iarchive ar(iss);
         ar >> *this;
       }
-      catch (...)
+      catch(...)
       {
-        crypto::chacha8(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), key, cache_file_data.iv, &cache_data[0]);
-        try
-        {
+        // try with previous scheme: direct from keys
+        crypto::chacha_key key;
+        generate_chacha_key_from_secret_keys(key);
+        crypto::chacha20(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), key, cache_file_data.iv, &cache_data[0]);
+        try {
           std::stringstream iss;
           iss << cache_data;
           boost::archive::portable_binary_iarchive ar(iss);
@@ -4097,13 +4308,24 @@ void wallet2::load(const std::string& wallet_, const epee::wipeable_string& pass
         }
         catch (...)
         {
-          LOG_PRINT_L0("Failed to open portable binary, trying unportable");
-          boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
-          std::stringstream iss;
-          iss.str("");
-          iss << cache_data;
-          boost::archive::binary_iarchive ar(iss);
-          ar >> *this;
+          crypto::chacha8(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), key, cache_file_data.iv, &cache_data[0]);
+          try
+          {
+            std::stringstream iss;
+            iss << cache_data;
+            boost::archive::portable_binary_iarchive ar(iss);
+            ar >> *this;
+          }
+          catch (...)
+          {
+            LOG_PRINT_L0("Failed to open portable binary, trying unportable");
+            boost::filesystem::copy_file(m_wallet_file, m_wallet_file + ".unportable", boost::filesystem::copy_option::overwrite_if_exists);
+            std::stringstream iss;
+            iss.str("");
+            iss << cache_data;
+            boost::archive::binary_iarchive ar(iss);
+            ar >> *this;
+          }
         }
       }
     }
@@ -4255,12 +4477,10 @@ void wallet2::store_to(const std::string &path, const epee::wipeable_string &pas
 
   wallet2::cache_file_data cache_file_data = boost::value_initialized<wallet2::cache_file_data>();
   cache_file_data.cache_data = oss.str();
-  crypto::chacha_key key;
-  generate_chacha_key_from_secret_keys(key);
   std::string cipher;
   cipher.resize(cache_file_data.cache_data.size());
   cache_file_data.iv = crypto::rand<crypto::chacha_iv>();
-  crypto::chacha20(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), key, cache_file_data.iv, &cipher[0]);
+  crypto::chacha20(cache_file_data.cache_data.data(), cache_file_data.cache_data.size(), m_cache_key, cache_file_data.iv, &cipher[0]);
   cache_file_data.cache_data = cipher;
 
   const std::string new_file = same_file ? m_wallet_file + ".new" : path;
@@ -5898,12 +6118,6 @@ crypto::chacha_key wallet2::get_ringdb_key()
   return *m_ringdb_key;
 }
 
-void wallet2::clear_ringdb_key()
-{
-  MINFO("clearing ringdb key");
-  m_ringdb_key = boost::none;
-}
-
 bool wallet2::add_rings(const crypto::chacha_key &key, const cryptonote::transaction_prefix &tx)
 {
   if (!m_ringdb)
@@ -5914,7 +6128,6 @@ bool wallet2::add_rings(const crypto::chacha_key &key, const cryptonote::transac
 
 bool wallet2::add_rings(const cryptonote::transaction_prefix &tx)
 {
-  key_ref kref(*this);
   try { return add_rings(get_ringdb_key(), tx); }
   catch (const std::exception &e) { return false; }
 }
@@ -5923,7 +6136,6 @@ bool wallet2::remove_rings(const cryptonote::transaction_prefix &tx)
 {
   if (!m_ringdb)
     return false;
-  key_ref kref(*this);
   try { return m_ringdb->remove_rings(get_ringdb_key(), tx); }
   catch (const std::exception &e) { return false; }
 }
@@ -5961,7 +6173,6 @@ bool wallet2::get_rings(const crypto::hash &txid, std::vector<std::pair<crypto::
 
 bool wallet2::get_ring(const crypto::key_image &key_image, std::vector<uint64_t> &outs)
 {
-  key_ref kref(*this);
   try { return get_ring(get_ringdb_key(), key_image, outs); }
   catch (const std::exception &e) { return false; }
 }
@@ -5971,7 +6182,6 @@ bool wallet2::set_ring(const crypto::key_image &key_image, const std::vector<uin
   if (!m_ringdb)
     return false;
 
-  key_ref kref(*this);
   try { return m_ringdb->set_ring(get_ringdb_key(), key_image, outs, relative); }
   catch (const std::exception &e) { return false; }
 }
@@ -5983,7 +6193,6 @@ bool wallet2::find_and_save_rings(bool force)
   if (!m_ringdb)
     return false;
 
-  key_ref kref(*this);
   COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
   COMMAND_RPC_GET_TRANSACTIONS::response res = AUTO_VAL_INIT(res);
 
@@ -10723,6 +10932,7 @@ size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs)
   m_multisig_rescan_info = &info;
   try
   {
+
     refresh(false);
   }
   catch (...) {}

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -797,7 +797,7 @@ bool wallet2::is_deterministic() const
   return keys_deterministic;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::get_seed(std::string& electrum_words, const epee::wipeable_string &passphrase) const
+bool wallet2::get_seed(epee::wipeable_string& electrum_words, const epee::wipeable_string &passphrase) const
 {
   bool keys_deterministic = is_deterministic();
   if (!keys_deterministic)
@@ -823,7 +823,7 @@ bool wallet2::get_seed(std::string& electrum_words, const epee::wipeable_string 
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::get_multisig_seed(std::string& seed, const epee::wipeable_string &passphrase, bool raw) const
+bool wallet2::get_multisig_seed(epee::wipeable_string& seed, const epee::wipeable_string &passphrase, bool raw) const
 {
   bool ready;
   uint32_t threshold, total;
@@ -846,7 +846,7 @@ bool wallet2::get_multisig_seed(std::string& seed, const epee::wipeable_string &
   crypto::secret_key skey;
   crypto::public_key pkey;
   const account_keys &keys = get_account().get_keys();
-  std::string data;
+  epee::wipeable_string data;
   data.append((const char*)&threshold, sizeof(uint32_t));
   data.append((const char*)&total, sizeof(uint32_t));
   skey = keys.m_spend_secret_key;
@@ -872,7 +872,7 @@ bool wallet2::get_multisig_seed(std::string& seed, const epee::wipeable_string &
 
   if (raw)
   {
-    seed = epee::string_tools::buff_to_hex_nodelimer(data);
+    seed = epee::to_hex::wipeable_string({(const unsigned char*)data.data(), data.size()});
   }
   else
   {
@@ -3198,7 +3198,7 @@ bool wallet2::verify_password(const std::string& keys_file_name, const epee::wip
  * \param  create_address_file  Whether to create an address file
  */
 void wallet2::generate(const std::string& wallet_, const epee::wipeable_string& password,
-  const std::string& multisig_data, bool create_address_file)
+  const epee::wipeable_string& multisig_data, bool create_address_file)
 {
   clear();
   prepare_file_names(wallet_);
@@ -10732,14 +10732,14 @@ size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs)
   return n_outputs;
 }
 //----------------------------------------------------------------------------------------------------
-std::string wallet2::encrypt(const std::string &plaintext, const crypto::secret_key &skey, bool authenticated) const
+std::string wallet2::encrypt(const char *plaintext, size_t len, const crypto::secret_key &skey, bool authenticated) const
 {
   crypto::chacha_key key;
   crypto::generate_chacha_key(&skey, sizeof(skey), key, m_kdf_rounds);
   std::string ciphertext;
   crypto::chacha_iv iv = crypto::rand<crypto::chacha_iv>();
-  ciphertext.resize(plaintext.size() + sizeof(iv) + (authenticated ? sizeof(crypto::signature) : 0));
-  crypto::chacha20(plaintext.data(), plaintext.size(), key, iv, &ciphertext[sizeof(iv)]);
+  ciphertext.resize(len + sizeof(iv) + (authenticated ? sizeof(crypto::signature) : 0));
+  crypto::chacha20(plaintext, len, key, iv, &ciphertext[sizeof(iv)]);
   memcpy(&ciphertext[0], &iv, sizeof(iv));
   if (authenticated)
   {
@@ -10753,12 +10753,28 @@ std::string wallet2::encrypt(const std::string &plaintext, const crypto::secret_
   return ciphertext;
 }
 //----------------------------------------------------------------------------------------------------
+std::string wallet2::encrypt(const epee::span<char> &plaintext, const crypto::secret_key &skey, bool authenticated) const
+{
+  return encrypt(plaintext.data(), plaintext.size(), skey, authenticated);
+}
+//----------------------------------------------------------------------------------------------------
+std::string wallet2::encrypt(const std::string &plaintext, const crypto::secret_key &skey, bool authenticated) const
+{
+  return encrypt(plaintext.data(), plaintext.size(), skey, authenticated);
+}
+//----------------------------------------------------------------------------------------------------
+std::string wallet2::encrypt(const epee::wipeable_string &plaintext, const crypto::secret_key &skey, bool authenticated) const
+{
+  return encrypt(plaintext.data(), plaintext.size(), skey, authenticated);
+}
+//----------------------------------------------------------------------------------------------------
 std::string wallet2::encrypt_with_view_secret_key(const std::string &plaintext, bool authenticated) const
 {
   return encrypt(plaintext, get_account().get_keys().m_view_secret_key, authenticated);
 }
 //----------------------------------------------------------------------------------------------------
-std::string wallet2::decrypt(const std::string &ciphertext, const crypto::secret_key &skey, bool authenticated) const
+template<typename T>
+T wallet2::decrypt(const std::string &ciphertext, const crypto::secret_key &skey, bool authenticated) const
 {
   const size_t prefix_size = sizeof(chacha_iv) + (authenticated ? sizeof(crypto::signature) : 0);
   THROW_WALLET_EXCEPTION_IF(ciphertext.size() < prefix_size,
@@ -10767,8 +10783,6 @@ std::string wallet2::decrypt(const std::string &ciphertext, const crypto::secret
   crypto::chacha_key key;
   crypto::generate_chacha_key(&skey, sizeof(skey), key, m_kdf_rounds);
   const crypto::chacha_iv &iv = *(const crypto::chacha_iv*)&ciphertext[0];
-  std::string plaintext;
-  plaintext.resize(ciphertext.size() - prefix_size);
   if (authenticated)
   {
     crypto::hash hash;
@@ -10779,9 +10793,13 @@ std::string wallet2::decrypt(const std::string &ciphertext, const crypto::secret
     THROW_WALLET_EXCEPTION_IF(!crypto::check_signature(hash, pkey, signature),
       error::wallet_internal_error, "Failed to authenticate ciphertext");
   }
-  crypto::chacha20(ciphertext.data() + sizeof(iv), ciphertext.size() - prefix_size, key, iv, &plaintext[0]);
-  return plaintext;
+  std::unique_ptr<char[]> buffer{new char[ciphertext.size() - prefix_size]};
+  auto wiper = epee::misc_utils::create_scope_leave_handler([&]() { memwipe(buffer.get(), ciphertext.size() - prefix_size); });
+  crypto::chacha20(ciphertext.data() + sizeof(iv), ciphertext.size() - prefix_size, key, iv, buffer.get());
+  return T(buffer.get(), ciphertext.size() - prefix_size);
 }
+//----------------------------------------------------------------------------------------------------
+template epee::wipeable_string wallet2::decrypt(const std::string &ciphertext, const crypto::secret_key &skey, bool authenticated) const;
 //----------------------------------------------------------------------------------------------------
 std::string wallet2::decrypt_with_view_secret_key(const std::string &ciphertext, bool authenticated) const
 {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -932,6 +932,7 @@ namespace tools
     void confirm_non_default_ring_size(bool always) { m_confirm_non_default_ring_size = always; }
 
     bool get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys) const;
+    void set_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys);
     void check_tx_key(const crypto::hash &txid, const crypto::secret_key &tx_key, const std::vector<crypto::secret_key> &additional_tx_keys, const cryptonote::account_public_address &address, uint64_t &received, bool &in_pool, uint64_t &confirmations);
     void check_tx_key_helper(const crypto::hash &txid, const crypto::key_derivation &derivation, const std::vector<crypto::key_derivation> &additional_derivations, const cryptonote::account_public_address &address, uint64_t &received, bool &in_pool, uint64_t &confirmations);
     std::string get_tx_proof(const crypto::hash &txid, const cryptonote::account_public_address &address, bool is_subaddress, const std::string &message);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -659,6 +659,7 @@ namespace tools
     // Subaddress scheme
     cryptonote::account_public_address get_subaddress(const cryptonote::subaddress_index& index) const;
     cryptonote::account_public_address get_address() const { return get_subaddress({0,0}); }
+    boost::optional<cryptonote::subaddress_index> get_subaddress_index(const cryptonote::account_public_address& address) const;
     crypto::public_key get_subaddress_spend_public_key(const cryptonote::subaddress_index& index) const;
     std::vector<crypto::public_key> get_subaddress_spend_public_keys(uint32_t account, uint32_t begin, uint32_t end) const;
     std::string get_subaddress_as_str(const cryptonote::subaddress_index& index) const;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1215,7 +1215,7 @@ namespace tools
     void cache_ringdb_key();
     void clear_ringdb_key();
 
-    bool get_output_distribution(uint64_t &start_height, std::vector<uint64_t> &distribution);
+    bool get_rct_distribution(uint64_t &start_height, std::vector<uint64_t> &distribution);
 
     uint64_t get_segregation_fork_height() const;
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -495,7 +495,7 @@ namespace tools
      * \param  create_address_file  Whether to create an address file
      */
     void generate(const std::string& wallet_, const epee::wipeable_string& password,
-      const std::string& multisig_data, bool create_address_file = false);
+      const epee::wipeable_string& multisig_data, bool create_address_file = false);
 
     /*!
      * \brief Generates a wallet or restores one.
@@ -637,7 +637,7 @@ namespace tools
      * \brief Checks if deterministic wallet
      */
     bool is_deterministic() const;
-    bool get_seed(std::string& electrum_words, const epee::wipeable_string &passphrase = epee::wipeable_string()) const;
+    bool get_seed(epee::wipeable_string& electrum_words, const epee::wipeable_string &passphrase = epee::wipeable_string()) const;
 
     /*!
     * \brief Checks if light wallet. A light wallet sends view key to a server where the blockchain is scanned.
@@ -691,7 +691,7 @@ namespace tools
     bool multisig(bool *ready = NULL, uint32_t *threshold = NULL, uint32_t *total = NULL) const;
     bool has_multisig_partial_key_images() const;
     bool has_unknown_key_images() const;
-    bool get_multisig_seed(std::string& seed, const epee::wipeable_string &passphrase = std::string(), bool raw = true) const;
+    bool get_multisig_seed(epee::wipeable_string& seed, const epee::wipeable_string &passphrase = std::string(), bool raw = true) const;
     bool key_on_device() const { return m_key_on_device; }
 
     // locked & unlocked balance of given or current subaddress account
@@ -1054,9 +1054,12 @@ namespace tools
     void update_pool_state(bool refreshed = false);
     void remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashes);
 
+    std::string encrypt(const char *plaintext, size_t len, const crypto::secret_key &skey, bool authenticated = true) const;
+    std::string encrypt(const epee::span<char> &span, const crypto::secret_key &skey, bool authenticated = true) const;
     std::string encrypt(const std::string &plaintext, const crypto::secret_key &skey, bool authenticated = true) const;
+    std::string encrypt(const epee::wipeable_string &plaintext, const crypto::secret_key &skey, bool authenticated = true) const;
     std::string encrypt_with_view_secret_key(const std::string &plaintext, bool authenticated = true) const;
-    std::string decrypt(const std::string &ciphertext, const crypto::secret_key &skey, bool authenticated = true) const;
+    template<typename T=std::string> T decrypt(const std::string &ciphertext, const crypto::secret_key &skey, bool authenticated = true) const;
     std::string decrypt_with_view_secret_key(const std::string &ciphertext, bool authenticated = true) const;
 
     std::string make_uri(const std::string &address, const std::string &payment_id, uint64_t amount, const std::string &tx_description, const std::string &recipient_name, std::string &error) const;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -165,9 +165,9 @@ namespace tools
     //! Just parses variables.
     static std::unique_ptr<wallet2> make_dummy(const boost::program_options::variables_map& vm, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
 
-    static bool verify_password(const std::string& keys_file_name, const epee::wipeable_string& password, bool no_spend_key, hw::device &hwdev);
+    static bool verify_password(const std::string& keys_file_name, const epee::wipeable_string& password, bool no_spend_key, hw::device &hwdev, uint64_t kdf_rounds);
 
-    wallet2(cryptonote::network_type nettype = cryptonote::MAINNET, bool restricted = false);
+    wallet2(cryptonote::network_type nettype = cryptonote::MAINNET, bool restricted = false, uint64_t kdf_rounds = 1);
     ~wallet2();
 
     struct multisig_info
@@ -1261,6 +1261,7 @@ namespace tools
     bool m_key_on_device;
     cryptonote::network_type m_nettype;
     bool m_restricted;
+    uint64_t m_kdf_rounds;
     std::string seed_language; /*!< Language of the mnemonics (seed). */
     bool is_old_file_format; /*!< Whether the wallet file is of an old file format */
     bool m_watch_only; /*!< no spend key */

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -260,12 +260,12 @@ namespace tools
       uint64_t m_block_height;
       uint64_t m_unlock_time;
       uint64_t m_timestamp;
+      bool m_coinbase;
       cryptonote::subaddress_index m_subaddr_index;
     };
 
     struct address_tx : payment_details
     {
-      bool m_coinbase;
       bool m_mempool;
       bool m_incoming;
     };
@@ -1327,7 +1327,7 @@ BOOST_CLASS_VERSION(tools::wallet2::transfer_details, 9)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_info, 1)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_info::LR, 0)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_tx_set, 1)
-BOOST_CLASS_VERSION(tools::wallet2::payment_details, 3)
+BOOST_CLASS_VERSION(tools::wallet2::payment_details, 4)
 BOOST_CLASS_VERSION(tools::wallet2::pool_payment_details, 1)
 BOOST_CLASS_VERSION(tools::wallet2::unconfirmed_transfer_details, 8)
 BOOST_CLASS_VERSION(tools::wallet2::confirmed_transfer_details, 6)
@@ -1594,16 +1594,24 @@ namespace boost
       a & x.m_timestamp;
       if (ver < 2)
       {
+        x.m_coinbase = false;
         x.m_subaddr_index = {};
         return;
       }
       a & x.m_subaddr_index;
       if (ver < 3)
       {
+        x.m_coinbase = false;
         x.m_fee = 0;
         return;
       }
       a & x.m_fee;
+      if (ver < 4)
+      {
+        x.m_coinbase = false;
+        return;
+      }
+      a & x.m_coinbase;
     }
 
     template <class Archive>

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -167,7 +167,7 @@ namespace tools
 
     static bool verify_password(const std::string& keys_file_name, const epee::wipeable_string& password, bool no_spend_key, hw::device &hwdev, uint64_t kdf_rounds);
 
-    wallet2(cryptonote::network_type nettype = cryptonote::MAINNET, bool restricted = false, uint64_t kdf_rounds = 1);
+    wallet2(cryptonote::network_type nettype = cryptonote::MAINNET, uint64_t kdf_rounds = 1);
     ~wallet2();
 
     struct multisig_info
@@ -687,7 +687,6 @@ namespace tools
     RefreshType get_refresh_type() const { return m_refresh_type; }
 
     cryptonote::network_type nettype() const { return m_nettype; }
-    bool restricted() const { return m_restricted; }
     bool watch_only() const { return m_watch_only; }
     bool multisig(bool *ready = NULL, uint32_t *threshold = NULL, uint32_t *total = NULL) const;
     bool has_multisig_partial_key_images() const;
@@ -1262,7 +1261,6 @@ namespace tools
     i_wallet2_callback* m_callback;
     bool m_key_on_device;
     cryptonote::network_type m_nettype;
-    bool m_restricted;
     uint64_t m_kdf_rounds;
     std::string seed_language; /*!< Language of the mnemonics (seed). */
     bool is_old_file_format; /*!< Whether the wallet file is of an old file format */

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -67,6 +67,19 @@ class Serialization_portability_wallet_Test;
 namespace tools
 {
   class ringdb;
+  class wallet2;
+
+  class wallet_keys_unlocker
+  {
+  public:
+    wallet_keys_unlocker(wallet2 &w, const boost::optional<tools::password_container> &password);
+    wallet_keys_unlocker(wallet2 &w, bool locked, const epee::wipeable_string &password);
+    ~wallet_keys_unlocker();
+  private:
+    wallet2 &w;
+    bool locked;
+    crypto::chacha_key key;
+  };
 
   class i_wallet2_callback
   {
@@ -77,6 +90,7 @@ namespace tools
     virtual void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index) {}
     virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index) {}
     virtual void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx) {}
+    virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason) { return boost::none; }
     // Light wallet callbacks
     virtual void on_lw_new_block(uint64_t height) {}
     virtual void on_lw_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount) {}
@@ -133,9 +147,11 @@ namespace tools
     std::deque<crypto::hash> m_blockchain;
   };
 
+  class wallet_keys_unlocker;
   class wallet2
   {
     friend class ::Serialization_portability_wallet_Test;
+    friend class wallet_keys_unlocker;
   public:
     static constexpr const std::chrono::seconds rpc_timeout = std::chrono::minutes(3) + std::chrono::seconds(30);
 
@@ -153,17 +169,17 @@ namespace tools
     static void init_options(boost::program_options::options_description& desc_params);
 
     //! Uses stdin and stdout. Returns a wallet2 if no errors.
-    static std::unique_ptr<wallet2> make_from_json(const boost::program_options::variables_map& vm, const std::string& json_file, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
+    static std::unique_ptr<wallet2> make_from_json(const boost::program_options::variables_map& vm, bool rpc, const std::string& json_file, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
 
     //! Uses stdin and stdout. Returns a wallet2 and password for `wallet_file` if no errors.
     static std::pair<std::unique_ptr<wallet2>, password_container>
-      make_from_file(const boost::program_options::variables_map& vm, const std::string& wallet_file, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
+      make_from_file(const boost::program_options::variables_map& vm, bool rpc, const std::string& wallet_file, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
 
     //! Uses stdin and stdout. Returns a wallet2 and password for wallet with no file if no errors.
-    static std::pair<std::unique_ptr<wallet2>, password_container> make_new(const boost::program_options::variables_map& vm, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
+    static std::pair<std::unique_ptr<wallet2>, password_container> make_new(const boost::program_options::variables_map& vm, bool rpc, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
 
     //! Just parses variables.
-    static std::unique_ptr<wallet2> make_dummy(const boost::program_options::variables_map& vm, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
+    static std::unique_ptr<wallet2> make_dummy(const boost::program_options::variables_map& vm, bool rpc, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
 
     static bool verify_password(const std::string& keys_file_name, const epee::wipeable_string& password, bool no_spend_key, hw::device &hwdev, uint64_t kdf_rounds);
 
@@ -477,16 +493,6 @@ namespace tools
       std::vector<is_out_data> additional;
     };
 
-    struct key_ref
-    {
-      key_ref(tools::wallet2 &w): wallet(w) { ++refs; }
-      ~key_ref() { if (!--refs) wallet.clear_ringdb_key(); }
-
-    private:
-      tools::wallet2 &wallet;
-      static std::atomic<unsigned int> refs;
-    };
-
     /*!
      * \brief  Generates a wallet or restores one.
      * \param  wallet_              Name of wallet file
@@ -613,6 +619,11 @@ namespace tools
     cryptonote::account_base& get_account(){return m_account;}
     const cryptonote::account_base& get_account()const{return m_account;}
 
+    void encrypt_keys(const crypto::chacha_key &key);
+    void encrypt_keys(const epee::wipeable_string &password);
+    void decrypt_keys(const crypto::chacha_key &key);
+    void decrypt_keys(const epee::wipeable_string &password);
+
     void set_refresh_from_block_height(uint64_t height) {m_refresh_from_block_height = height;}
     uint64_t get_refresh_from_block_height() const {return m_refresh_from_block_height;}
 
@@ -625,7 +636,7 @@ namespace tools
     // into account the current median block size rather than
     // the minimum block size.
     bool deinit();
-    bool init(std::string daemon_address = "http://localhost:8080",
+    bool init(bool rpc, std::string daemon_address = "http://localhost:8080",
       boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_size_limit = 0, bool ssl = false);
 
     void stop() { m_run.store(false, std::memory_order_relaxed); }
@@ -1077,6 +1088,8 @@ namespace tools
     uint64_t adjust_ring_size(uint64_t ring_size) const;
     uint32_t adjust_priority(uint32_t priority);
 
+    bool is_rpc() const { return m_rpc; }
+
     // Light wallet specific functions
     // fetch unspent outs from lw node and store in m_transfers
     void light_wallet_get_unspent_outs();
@@ -1153,6 +1166,9 @@ namespace tools
     bool lock_keys_file();
     bool unlock_keys_file();
     bool is_keys_file_locked() const;
+
+    void change_password(const std::string &filename, const epee::wipeable_string &original_password, const epee::wipeable_string &new_password);
+
   private:
     /*!
      * \brief  Stores wallet information to wallet file.
@@ -1187,6 +1203,7 @@ namespace tools
     void generate_genesis(cryptonote::block& b) const;
     void check_genesis(const crypto::hash& genesis_hash) const; //throws
     bool generate_chacha_key_from_secret_keys(crypto::chacha_key &key) const;
+    void generate_chacha_key_from_password(const epee::wipeable_string &pass, crypto::chacha_key &key) const;
     crypto::hash get_payment_id(const pending_tx &ptx) const;
     void check_acc_out_precomp(const cryptonote::tx_out &o, const crypto::key_derivation &derivation, const std::vector<crypto::key_derivation> &additional_derivations, size_t i, tx_scan_info_t &tx_scan_info) const;
     void check_acc_out_precomp(const cryptonote::tx_out &o, const crypto::key_derivation &derivation, const std::vector<crypto::key_derivation> &additional_derivations, size_t i, const is_out_data *is_out_data, tx_scan_info_t &tx_scan_info) const;
@@ -1204,7 +1221,7 @@ namespace tools
     crypto::public_key get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const;
     bool should_pick_a_second_output(bool use_rct, size_t n_transfers, const std::vector<size_t> &unused_transfers_indices, const std::vector<size_t> &unused_dust_indices) const;
     std::vector<size_t> get_only_rct(const std::vector<size_t> &unused_dust_indices, const std::vector<size_t> &unused_transfers_indices) const;
-    void scan_output(const cryptonote::transaction &tx, bool miner_tx, const crypto::public_key &tx_pub_key, size_t i, tx_scan_info_t &tx_scan_info, int &num_vouts_received, std::unordered_map<cryptonote::subaddress_index, uint64_t> &tx_money_got_in_outs, std::vector<size_t> &outs) const;
+    void scan_output(const cryptonote::transaction &tx, bool miner_tx, const crypto::public_key &tx_pub_key, size_t i, tx_scan_info_t &tx_scan_info, int &num_vouts_received, std::unordered_map<cryptonote::subaddress_index, uint64_t> &tx_money_got_in_outs, std::vector<size_t> &outs);
     void trim_hashchain();
     crypto::key_image get_multisig_composite_key_image(size_t n) const;
     rct::multisig_kLRki get_multisig_composite_kLRki(size_t n, const crypto::public_key &ignore, std::unordered_set<rct::key> &used_L, std::unordered_set<rct::key> &new_used_L) const;
@@ -1216,8 +1233,7 @@ namespace tools
     bool remove_rings(const cryptonote::transaction_prefix &tx);
     bool get_ring(const crypto::chacha_key &key, const crypto::key_image &key_image, std::vector<uint64_t> &outs);
     crypto::chacha_key get_ringdb_key();
-    void cache_ringdb_key();
-    void clear_ringdb_key();
+    void setup_keys(const epee::wipeable_string &password);
 
     bool get_rct_distribution(uint64_t &start_height, std::vector<uint64_t> &distribution);
 
@@ -1323,6 +1339,11 @@ namespace tools
 
     uint64_t m_last_block_reward;
     std::unique_ptr<tools::file_locker> m_keys_file_locker;
+
+    crypto::chacha_key m_cache_key;
+    boost::optional<epee::wipeable_string> m_encrypt_keys_after_refresh;
+
+    bool m_rpc;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 25)

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -109,6 +109,9 @@ namespace wallet_args
 
     std::string lang = i18n_get_language();
     tools::on_startup();
+#ifdef NDEBUG
+    tools::disable_core_dumps();
+#endif
     tools::set_strict_default_file_permissions(true);
 
     epee::string_tools::set_module_name_and_folder(argv[0]);

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -53,6 +53,7 @@ namespace tools
     //         wallet_not_initialized
     //       multisig_export_needed
     //       multisig_import_needed
+    //       password_needed
     //   std::logic_error
     //     wallet_logic_error *
     //       file_exists
@@ -205,6 +206,14 @@ namespace tools
     {
       explicit multisig_import_needed(std::string&& loc)
         : wallet_runtime_error(std::move(loc), "Not enough multisig data was found to sign: import multisig data from more other participants")
+      {
+      }
+    };
+    //----------------------------------------------------------------------------------------------------
+    struct password_needed : public wallet_runtime_error
+    {
+      explicit password_needed(std::string&& loc, const std::string &msg = "Password needed")
+        : wallet_runtime_error(std::move(loc), msg)
       {
       }
     };

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -270,7 +270,7 @@ namespace tools
     entry.unlock_time = pd.m_unlock_time;
     entry.fee = pd.m_fee;
     entry.note = m_wallet->get_tx_note(pd.m_tx_hash);
-    entry.type = "in";
+    entry.type = pd.m_coinbase ? "block" : "in";
     entry.subaddr_index = pd.m_subaddr_index;
     entry.address = m_wallet->get_subaddress_as_str(pd.m_subaddr_index);
     set_confirmations(entry, m_wallet->get_blockchain_current_height(), m_wallet->get_last_block_reward());

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -416,6 +416,27 @@ namespace tools
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool wallet_rpc_server::on_getaddress_index(const wallet_rpc::COMMAND_RPC_GET_ADDRESS_INDEX::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS_INDEX::response& res, epee::json_rpc::error& er)
+  {
+    if (!m_wallet) return not_open(er);
+    cryptonote::address_parse_info info;
+    if(!get_account_address_from_str(info, m_wallet->nettype(), req.address))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
+      er.message = "Invalid address";
+      return false;
+    }
+    auto index = m_wallet->get_subaddress_index(info.address);
+    if (!index)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
+      er.message = "Address doesn't belong to the wallet";
+      return false;
+    }
+    res.index = *index;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_create_address(const wallet_rpc::COMMAND_RPC_CREATE_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_CREATE_ADDRESS::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2523,6 +2523,28 @@ namespace tools
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool wallet_rpc_server::on_refresh(const wallet_rpc::COMMAND_RPC_REFRESH::request& req, wallet_rpc::COMMAND_RPC_REFRESH::response& res, epee::json_rpc::error& er)
+  {
+    if (!m_wallet) return not_open(er);
+    if (m_restricted)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_DENIED;
+      er.message = "Command unavailable in restricted mode.";
+      return false;
+    }
+    try
+    {
+      m_wallet->refresh(m_trusted_daemon, req.start_height, res.blocks_fetched, res.received_money);
+      return true;
+    }
+    catch (const std::exception& e)
+    {
+      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+      return false;
+    }
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_rescan_spent(const wallet_rpc::COMMAND_RPC_RESCAN_SPENT::request& req, wallet_rpc::COMMAND_RPC_RESCAN_SPENT::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1590,11 +1590,13 @@ namespace tools
 
       if (req.key_type.compare("mnemonic") == 0)
       {
-        if (!m_wallet->get_seed(res.key))
+        epee::wipeable_string seed;
+        if (!m_wallet->get_seed(seed))
         {
             er.message = "The wallet is non-deterministic. Cannot display seed.";
             return false;
         }
+        res.key = std::string(seed.data(), seed.size()); // send to the network, then wipe RAM :D
       }
       else if(req.key_type.compare("view_key") == 0)
       {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -60,6 +60,7 @@ namespace
   const command_line::arg_descriptor<std::string, true> arg_rpc_bind_port = {"rpc-bind-port", "Sets bind port for server"};
   const command_line::arg_descriptor<bool> arg_disable_rpc_login = {"disable-rpc-login", "Disable HTTP authentication for RPC connections served by this process"};
   const command_line::arg_descriptor<bool> arg_trusted_daemon = {"trusted-daemon", "Enable commands which rely on a trusted daemon", false};
+  const command_line::arg_descriptor<bool> arg_restricted = {"restricted-rpc", "Restricts to view-only commands", false};
   const command_line::arg_descriptor<std::string> arg_wallet_dir = {"wallet-dir", "Directory for newly created wallets"};
   const command_line::arg_descriptor<bool> arg_prompt_for_password = {"prompt-for-password", "Prompts for password when not provided", false};
 
@@ -99,7 +100,7 @@ namespace tools
   }
 
   //------------------------------------------------------------------------------------------------------------------------------
-  wallet_rpc_server::wallet_rpc_server():m_wallet(NULL), rpc_login_file(), m_stop(false), m_trusted_daemon(false), m_vm(NULL)
+  wallet_rpc_server::wallet_rpc_server():m_wallet(NULL), rpc_login_file(), m_stop(false), m_trusted_daemon(false), m_restricted(false), m_vm(NULL)
   {
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -177,6 +178,7 @@ namespace tools
         m_trusted_daemon = true;
       }
     }
+    m_restricted = command_line::get_arg(*m_vm, arg_restricted);
     if (command_line::has_arg(*m_vm, arg_wallet_dir))
     {
       m_wallet_dir = command_line::get_arg(*m_vm, arg_wallet_dir);
@@ -830,7 +832,7 @@ namespace tools
 
     LOG_PRINT_L3("on_transfer starts");
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -894,7 +896,7 @@ namespace tools
     std::vector<uint8_t> extra;
 
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -941,7 +943,7 @@ namespace tools
   bool wallet_rpc_server::on_sign_transfer(const wallet_rpc::COMMAND_RPC_SIGN_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_SIGN_TRANSFER::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1016,7 +1018,7 @@ namespace tools
   bool wallet_rpc_server::on_submit_transfer(const wallet_rpc::COMMAND_RPC_SUBMIT_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_SUBMIT_TRANSFER::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1076,7 +1078,7 @@ namespace tools
   bool wallet_rpc_server::on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1104,7 +1106,7 @@ namespace tools
     std::vector<uint8_t> extra;
 
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1156,7 +1158,7 @@ namespace tools
     std::vector<uint8_t> extra;
 
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1376,7 +1378,7 @@ namespace tools
   bool wallet_rpc_server::on_store(const wallet_rpc::COMMAND_RPC_STORE::request& req, wallet_rpc::COMMAND_RPC_STORE::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1579,7 +1581,7 @@ namespace tools
   bool wallet_rpc_server::on_query_key(const wallet_rpc::COMMAND_RPC_QUERY_KEY::request& req, wallet_rpc::COMMAND_RPC_QUERY_KEY::response& res, epee::json_rpc::error& er)
   {
       if (!m_wallet) return not_open(er);
-      if (m_wallet->restricted())
+      if (m_restricted)
       {
         er.code = WALLET_RPC_ERROR_CODE_DENIED;
         er.message = "Command unavailable in restricted mode.";
@@ -1614,7 +1616,7 @@ namespace tools
   bool wallet_rpc_server::on_rescan_blockchain(const wallet_rpc::COMMAND_RPC_RESCAN_BLOCKCHAIN::request& req, wallet_rpc::COMMAND_RPC_RESCAN_BLOCKCHAIN::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1636,7 +1638,7 @@ namespace tools
   bool wallet_rpc_server::on_sign(const wallet_rpc::COMMAND_RPC_SIGN::request& req, wallet_rpc::COMMAND_RPC_SIGN::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1650,7 +1652,7 @@ namespace tools
   bool wallet_rpc_server::on_verify(const wallet_rpc::COMMAND_RPC_VERIFY::request& req, wallet_rpc::COMMAND_RPC_VERIFY::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1685,7 +1687,7 @@ namespace tools
   bool wallet_rpc_server::on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP_WALLET::request& req, wallet_rpc::COMMAND_RPC_STOP_WALLET::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1708,7 +1710,7 @@ namespace tools
   bool wallet_rpc_server::on_set_tx_notes(const wallet_rpc::COMMAND_RPC_SET_TX_NOTES::request& req, wallet_rpc::COMMAND_RPC_SET_TX_NOTES::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1780,7 +1782,7 @@ namespace tools
   bool wallet_rpc_server::on_set_attribute(const wallet_rpc::COMMAND_RPC_SET_ATTRIBUTE::request& req, wallet_rpc::COMMAND_RPC_SET_ATTRIBUTE::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -1795,7 +1797,7 @@ namespace tools
   bool wallet_rpc_server::on_get_attribute(const wallet_rpc::COMMAND_RPC_GET_ATTRIBUTE::request& req, wallet_rpc::COMMAND_RPC_GET_ATTRIBUTE::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2071,7 +2073,7 @@ namespace tools
   bool wallet_rpc_server::on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2137,7 +2139,7 @@ namespace tools
   bool wallet_rpc_server::on_get_transfer_by_txid(const wallet_rpc::COMMAND_RPC_GET_TRANSFER_BY_TXID::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFER_BY_TXID::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2221,7 +2223,7 @@ namespace tools
   bool wallet_rpc_server::on_export_outputs(const wallet_rpc::COMMAND_RPC_EXPORT_OUTPUTS::request& req, wallet_rpc::COMMAND_RPC_EXPORT_OUTPUTS::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2250,7 +2252,7 @@ namespace tools
   bool wallet_rpc_server::on_import_outputs(const wallet_rpc::COMMAND_RPC_IMPORT_OUTPUTS::request& req, wallet_rpc::COMMAND_RPC_IMPORT_OUTPUTS::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2310,7 +2312,7 @@ namespace tools
   bool wallet_rpc_server::on_import_key_images(const wallet_rpc::COMMAND_RPC_IMPORT_KEY_IMAGES::request& req, wallet_rpc::COMMAND_RPC_IMPORT_KEY_IMAGES::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2421,7 +2423,7 @@ namespace tools
   bool wallet_rpc_server::on_add_address_book(const wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2496,7 +2498,7 @@ namespace tools
   bool wallet_rpc_server::on_delete_address_book(const wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2522,7 +2524,7 @@ namespace tools
   bool wallet_rpc_server::on_rescan_spent(const wallet_rpc::COMMAND_RPC_RESCAN_SPENT::request& req, wallet_rpc::COMMAND_RPC_RESCAN_SPENT::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2829,7 +2831,7 @@ namespace tools
   bool wallet_rpc_server::on_prepare_multisig(const wallet_rpc::COMMAND_RPC_PREPARE_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_PREPARE_MULTISIG::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2855,7 +2857,7 @@ namespace tools
   bool wallet_rpc_server::on_make_multisig(const wallet_rpc::COMMAND_RPC_MAKE_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_MAKE_MULTISIG::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2892,7 +2894,7 @@ namespace tools
   bool wallet_rpc_server::on_export_multisig(const wallet_rpc::COMMAND_RPC_EXPORT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_EXPORT_MULTISIG::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -2932,7 +2934,7 @@ namespace tools
   bool wallet_rpc_server::on_import_multisig(const wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -3005,7 +3007,7 @@ namespace tools
   bool wallet_rpc_server::on_finalize_multisig(const wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_FINALIZE_MULTISIG::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -3056,7 +3058,7 @@ namespace tools
   bool wallet_rpc_server::on_sign_multisig(const wallet_rpc::COMMAND_RPC_SIGN_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_SIGN_MULTISIG::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -3125,7 +3127,7 @@ namespace tools
   bool wallet_rpc_server::on_submit_multisig(const wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_SUBMIT_MULTISIG::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);
-    if (m_wallet->restricted())
+    if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
@@ -3207,6 +3209,7 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_rpc_bind_port);
   command_line::add_arg(desc_params, arg_disable_rpc_login);
   command_line::add_arg(desc_params, arg_trusted_daemon);
+  command_line::add_arg(desc_params, arg_restricted);
   cryptonote::rpc_args::init_options(desc_params);
   command_line::add_arg(desc_params, arg_wallet_file);
   command_line::add_arg(desc_params, arg_from_json);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1271,7 +1271,39 @@ namespace tools
         }
       }
 
-      res.integrated_address = m_wallet->get_integrated_address_as_str(payment_id);
+      if (req.standard_address.empty())
+      {
+        res.integrated_address = m_wallet->get_integrated_address_as_str(payment_id);
+      }
+      else
+      {
+        cryptonote::address_parse_info info;
+        if(!get_account_address_from_str(info, m_wallet->nettype(), req.standard_address))
+        {
+          er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
+          er.message = "Invalid address";
+          return false;
+        }
+        if (info.is_subaddress)
+        {
+          er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
+          er.message = "Subaddress shouldn't be used";
+          return false;
+        }
+        if (info.has_payment_id)
+        {
+          er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
+          er.message = "Already integrated address";
+          return false;
+        }
+        if (req.payment_id.empty())
+        {
+          er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
+          er.message = "Payment ID shouldn't be left unspecified";
+          return false;
+        }
+        res.integrated_address = get_account_integrated_address_as_str(m_wallet->nettype(), info.address, payment_id);
+      }
       res.payment_id = epee::string_tools::pod_to_hex(payment_id);
       return true;
     }

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -163,7 +163,7 @@ namespace tools
       walvars = m_wallet;
     else
     {
-      tmpwal = tools::wallet2::make_dummy(*m_vm, password_prompter);
+      tmpwal = tools::wallet2::make_dummy(*m_vm, true, password_prompter);
       walvars = tmpwal.get();
     }
     boost::optional<epee::net_utils::http::login> http_login{};
@@ -2654,7 +2654,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, nullptr).first;
+    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, true, nullptr).first;
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
@@ -2728,7 +2728,7 @@ namespace tools
     }
     std::unique_ptr<tools::wallet2> wal = nullptr;
     try {
-      wal = tools::wallet2::make_from_file(vm2, wallet_file, nullptr).first;
+      wal = tools::wallet2::make_from_file(vm2, true, wallet_file, nullptr).first;
     }
     catch (const std::exception& e)
     {
@@ -3277,13 +3277,13 @@ int main(int argc, char** argv) {
     LOG_PRINT_L0(tools::wallet_rpc_server::tr("Loading wallet..."));
     if(!wallet_file.empty())
     {
-      wal = tools::wallet2::make_from_file(*vm, wallet_file, password_prompt).first;
+      wal = tools::wallet2::make_from_file(*vm, true, wallet_file, password_prompt).first;
     }
     else
     {
       try
       {
-        wal = tools::wallet2::make_from_json(*vm, from_json, password_prompt);
+        wal = tools::wallet2::make_from_json(*vm, true, from_json, password_prompt);
       }
       catch (const std::exception &e)
       {

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -126,6 +126,7 @@ namespace tools
         MAP_JON_RPC_WE("get_address_book",   on_get_address_book,   wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY)
         MAP_JON_RPC_WE("add_address_book",   on_add_address_book,   wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY)
         MAP_JON_RPC_WE("delete_address_book",on_delete_address_book,wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY)
+        MAP_JON_RPC_WE("refresh",            on_refresh,            wallet_rpc::COMMAND_RPC_REFRESH)
         MAP_JON_RPC_WE("rescan_spent",       on_rescan_spent,       wallet_rpc::COMMAND_RPC_RESCAN_SPENT)
         MAP_JON_RPC_WE("start_mining",       on_start_mining,       wallet_rpc::COMMAND_RPC_START_MINING)
         MAP_JON_RPC_WE("stop_mining",        on_stop_mining,        wallet_rpc::COMMAND_RPC_STOP_MINING)
@@ -202,6 +203,7 @@ namespace tools
       bool on_get_address_book(const wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er);
       bool on_add_address_book(const wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er);
       bool on_delete_address_book(const wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er);
+      bool on_refresh(const wallet_rpc::COMMAND_RPC_REFRESH::request& req, wallet_rpc::COMMAND_RPC_REFRESH::response& res, epee::json_rpc::error& er);
       bool on_rescan_spent(const wallet_rpc::COMMAND_RPC_RESCAN_SPENT::request& req, wallet_rpc::COMMAND_RPC_RESCAN_SPENT::response& res, epee::json_rpc::error& er);
       bool on_start_mining(const wallet_rpc::COMMAND_RPC_START_MINING::request& req, wallet_rpc::COMMAND_RPC_START_MINING::response& res, epee::json_rpc::error& er);
       bool on_stop_mining(const wallet_rpc::COMMAND_RPC_STOP_MINING::request& req, wallet_rpc::COMMAND_RPC_STOP_MINING::response& res, epee::json_rpc::error& er);

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -239,6 +239,7 @@ namespace tools
       tools::private_file rpc_login_file;
       std::atomic<bool> m_stop;
       bool m_trusted_daemon;
+      bool m_restricted;
       const boost::program_options::variables_map *m_vm;
   };
 }

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -69,6 +69,7 @@ namespace tools
       BEGIN_JSON_RPC_MAP("/json_rpc")
         MAP_JON_RPC_WE("get_balance",        on_getbalance,         wallet_rpc::COMMAND_RPC_GET_BALANCE)
         MAP_JON_RPC_WE("get_address",        on_getaddress,         wallet_rpc::COMMAND_RPC_GET_ADDRESS)
+        MAP_JON_RPC_WE("get_address_index",  on_getaddress_index,   wallet_rpc::COMMAND_RPC_GET_ADDRESS_INDEX)
         MAP_JON_RPC_WE("getbalance",         on_getbalance,         wallet_rpc::COMMAND_RPC_GET_BALANCE)
         MAP_JON_RPC_WE("getaddress",         on_getaddress,         wallet_rpc::COMMAND_RPC_GET_ADDRESS)
         MAP_JON_RPC_WE("create_address",     on_create_address,     wallet_rpc::COMMAND_RPC_CREATE_ADDRESS)
@@ -148,6 +149,7 @@ namespace tools
       //json_rpc
       bool on_getbalance(const wallet_rpc::COMMAND_RPC_GET_BALANCE::request& req, wallet_rpc::COMMAND_RPC_GET_BALANCE::response& res, epee::json_rpc::error& er);
       bool on_getaddress(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS::response& res, epee::json_rpc::error& er);
+      bool on_getaddress_index(const wallet_rpc::COMMAND_RPC_GET_ADDRESS_INDEX::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS_INDEX::response& res, epee::json_rpc::error& er);
       bool on_create_address(const wallet_rpc::COMMAND_RPC_CREATE_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_CREATE_ADDRESS::response& res, epee::json_rpc::error& er);
       bool on_label_address(const wallet_rpc::COMMAND_RPC_LABEL_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_LABEL_ADDRESS::response& res, epee::json_rpc::error& er);
       bool on_get_accounts(const wallet_rpc::COMMAND_RPC_GET_ACCOUNTS::request& req, wallet_rpc::COMMAND_RPC_GET_ACCOUNTS::response& res, epee::json_rpc::error& er);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -62,8 +62,10 @@ namespace wallet_rpc
     struct request
     {
       uint32_t account_index;
+      std::set<uint32_t> address_indices;
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
+        KV_SERIALIZE(address_indices)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -914,9 +914,11 @@ namespace wallet_rpc
   {
     struct request
     {
+      std::string standard_address;
       std::string payment_id;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(standard_address)
         KV_SERIALIZE(payment_id)
       END_KV_SERIALIZE_MAP()
     };

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -1714,6 +1714,29 @@ namespace wallet_rpc
     };
   };
 
+  struct COMMAND_RPC_REFRESH
+  {
+    struct request
+    {
+      uint64_t start_height;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_OPT(start_height, (uint64_t) 0)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      uint64_t blocks_fetched;
+      bool received_money;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(blocks_fetched);
+        KV_SERIALIZE(received_money);
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_START_MINING
   {
     struct request

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -47,7 +47,7 @@
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 1
+#define WALLET_RPC_VERSION_MINOR 2
 #define MAKE_WALLET_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define WALLET_RPC_VERSION MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
 namespace tools
@@ -137,6 +137,25 @@ namespace wallet_rpc
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
         KV_SERIALIZE(addresses)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
+  struct COMMAND_RPC_GET_ADDRESS_INDEX
+  {
+    struct request
+    {
+      std::string address;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(address)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      cryptonote::subaddress_index index;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(index)
       END_KV_SERIALIZE_MAP()
     };
   };

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -138,7 +138,7 @@ bool transactions_flow_test(std::string& working_folder,
     return false;
   }
 
-  w1.init(daemon_addr_a);
+  w1.init(true, daemon_addr_a);
 
   uint64_t blocks_fetched = 0;
   bool received_money;
@@ -149,7 +149,7 @@ bool transactions_flow_test(std::string& working_folder,
     return false;
   }
 
-  w2.init(daemon_addr_b);
+  w2.init(true, daemon_addr_b);
 
   MGINFO_GREEN("Using wallets: " << ENDL
     << "Source:  " << w1.get_account().get_public_address_str(MAINNET) << ENDL << "Path: " << working_folder + "/" + path_source_wallet << ENDL

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -27,6 +27,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(unit_tests_sources
+  account.cpp
   apply_permutation.cpp
   address_from_url.cpp
   ban.cpp

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -73,7 +73,8 @@ set(unit_tests_sources
   ringct.cpp
   output_selection.cpp
   vercmp.cpp
-  ringdb.cpp)
+  ringdb.cpp
+  wipeable_string.cpp)
 
 set(unit_tests_headers
   unit_tests_utils.h)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(unit_tests_sources
   epee_levin_protocol_handler_async.cpp
   epee_utils.cpp
   fee.cpp
+  json_serialization.cpp
   get_xtype_from_string.cpp
   hashchain.cpp
   http.cpp
@@ -91,6 +92,7 @@ target_link_libraries(unit_tests
     cryptonote_core
     blockchain_db
     rpc
+    serialization
     wallet
     p2p
     version

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(unit_tests_sources
   http.cpp
   main.cpp
   memwipe.cpp
+  mlocker.cpp
   mnemonics.cpp
   mul_div.cpp
   int-util.cpp

--- a/tests/unit_tests/account.cpp
+++ b/tests/unit_tests/account.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2014-2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include "cryptonote_basic/account.h"
+
+TEST(account, encrypt_keys)
+{
+  cryptonote::keypair recovery_key = cryptonote::keypair::generate(hw::get_device("default"));
+  cryptonote::account_base account;
+  crypto::secret_key key = account.generate(recovery_key.sec);
+  const cryptonote::account_keys keys = account.get_keys();
+
+  ASSERT_EQ(account.get_keys().m_account_address, keys.m_account_address);
+  ASSERT_EQ(account.get_keys().m_spend_secret_key, keys.m_spend_secret_key);
+  ASSERT_EQ(account.get_keys().m_view_secret_key, keys.m_view_secret_key);
+  ASSERT_EQ(account.get_keys().m_multisig_keys, keys.m_multisig_keys);
+
+  crypto::chacha_key chacha_key;
+  crypto::generate_chacha_key(&recovery_key, sizeof(recovery_key), chacha_key, 1);
+
+  account.encrypt_keys(chacha_key);
+
+  ASSERT_EQ(account.get_keys().m_account_address, keys.m_account_address);
+  ASSERT_NE(account.get_keys().m_spend_secret_key, keys.m_spend_secret_key);
+  ASSERT_NE(account.get_keys().m_view_secret_key, keys.m_view_secret_key);
+
+  account.decrypt_viewkey(chacha_key);
+
+  ASSERT_EQ(account.get_keys().m_account_address, keys.m_account_address);
+  ASSERT_NE(account.get_keys().m_spend_secret_key, keys.m_spend_secret_key);
+  ASSERT_EQ(account.get_keys().m_view_secret_key, keys.m_view_secret_key);
+
+  account.encrypt_viewkey(chacha_key);
+
+  ASSERT_EQ(account.get_keys().m_account_address, keys.m_account_address);
+  ASSERT_NE(account.get_keys().m_spend_secret_key, keys.m_spend_secret_key);
+  ASSERT_NE(account.get_keys().m_view_secret_key, keys.m_view_secret_key);
+
+  account.decrypt_keys(chacha_key);
+
+  ASSERT_EQ(account.get_keys().m_account_address, keys.m_account_address);
+  ASSERT_EQ(account.get_keys().m_spend_secret_key, keys.m_spend_secret_key);
+  ASSERT_EQ(account.get_keys().m_view_secret_key, keys.m_view_secret_key);
+}

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -88,3 +88,11 @@ TEST(Crypto, verify_32)
     }
   }
 }
+
+TEST(Crypto, null_keys)
+{
+  char zero[32];
+  memset(zero, 0, 32);
+  ASSERT_EQ(memcmp(crypto::null_skey.data, zero, 32), 0);
+  ASSERT_EQ(memcmp(crypto::null_pkey.data, zero, 32), 0);
+}

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -74,6 +74,14 @@ TEST(Crypto, Ostream)
   EXPECT_TRUE(is_formatted<crypto::key_image>());
 }
 
+TEST(Crypto, null_keys)
+{
+  char zero[32];
+  memset(zero, 0, 32);
+  ASSERT_EQ(memcmp(crypto::null_skey.data, zero, 32), 0);
+  ASSERT_EQ(memcmp(crypto::null_pkey.data, zero, 32), 0);
+}
+
 TEST(Crypto, verify_32)
 {
   // all bytes are treated the same, so we can brute force just one byte
@@ -87,12 +95,4 @@ TEST(Crypto, verify_32)
       ASSERT_EQ(!crypto_verify_32(k0, k1), i0 == i1);
     }
   }
-}
-
-TEST(Crypto, null_keys)
-{
-  char zero[32];
-  memset(zero, 0, 32);
-  ASSERT_EQ(memcmp(crypto::null_skey.data, zero, 32), 0);
-  ASSERT_EQ(memcmp(crypto::null_pkey.data, zero, 32), 0);
 }

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -93,7 +93,6 @@ public:
   virtual uint64_t get_num_outputs(const uint64_t& amount) const { return 1; }
   virtual uint64_t get_indexing_base() const { return 0; }
   virtual output_data_t get_output_key(const uint64_t& amount, const uint64_t& index) { return output_data_t(); }
-  virtual output_data_t get_output_key(const uint64_t& global_index) const { return output_data_t(); }
   virtual tx_out_index get_output_tx_and_index_from_global(const uint64_t& index) const { return tx_out_index(); }
   virtual tx_out_index get_output_tx_and_index(const uint64_t& amount, const uint64_t& index) const { return tx_out_index(); }
   virtual void get_output_tx_and_index(const uint64_t& amount, const std::vector<uint64_t> &offsets, std::vector<tx_out_index> &indices) const {}

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -1,0 +1,217 @@
+
+#include <boost/optional/optional.hpp>
+#include <boost/range/adaptor/indexed.hpp>
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+#include <vector>
+
+#include "crypto/hash.h"
+#include "cryptonote_basic/account.h"
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_core/cryptonote_tx_utils.h"
+#include "serialization/json_object.h"
+
+
+namespace
+{
+    cryptonote::transaction
+    make_miner_transaction(cryptonote::account_public_address const& to)
+    {
+        cryptonote::transaction tx{};
+        if (!cryptonote::construct_miner_tx(0, 0, 5000, 500, 500, to, tx))
+            throw std::runtime_error{"transaction construction error"};
+
+        crypto::hash id{0};
+        if (!cryptonote::get_transaction_hash(tx, id))
+            throw std::runtime_error{"could not get transaction hash"};
+
+        return tx;
+    }
+
+    cryptonote::transaction
+    make_transaction(
+        cryptonote::account_keys const& from,
+        std::vector<cryptonote::transaction> const& sources,
+        std::vector<cryptonote::account_public_address> const& destinations,
+        bool rct,
+        bool bulletproof)
+    {
+        std::uint64_t source_amount = 0;
+        std::vector<cryptonote::tx_source_entry> actual_sources;
+        for (auto const& source : sources)
+        {
+            std::vector<cryptonote::tx_extra_field> extra_fields;
+            if (!cryptonote::parse_tx_extra(source.extra, extra_fields))
+                throw std::runtime_error{"invalid transaction"};
+
+            cryptonote::tx_extra_pub_key key_field{};
+            if (!cryptonote::find_tx_extra_field_by_type(extra_fields, key_field))
+                throw std::runtime_error{"invalid transaction"};
+
+            for (auto const& input : boost::adaptors::index(source.vout))
+            {
+                source_amount += input.value().amount;
+                auto const& key = boost::get<cryptonote::txout_to_key>(input.value().target);
+
+                actual_sources.push_back(
+                    {{}, 0, key_field.pub_key, {}, std::size_t(input.index()), input.value().amount, rct, rct::identity()}
+                );
+
+                for (unsigned ring = 0; ring < 10; ++ring)
+                    actual_sources.back().push_output(input.index(), key.key, input.value().amount);
+            }
+        }
+
+        std::vector<cryptonote::tx_destination_entry> to;
+        for (auto const& destination : destinations)
+            to.push_back({(source_amount / destinations.size()), destination, false});
+
+        cryptonote::transaction tx{};
+
+        crypto::secret_key tx_key{};
+        std::vector<crypto::secret_key> extra_keys{};
+
+        std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
+        subaddresses[from.m_account_address.m_spend_public_key] = {0,0};
+
+        if (!cryptonote::construct_tx_and_get_tx_key(from, subaddresses, actual_sources, to, boost::none, {}, tx, 0, tx_key, extra_keys, rct, bulletproof))
+            throw std::runtime_error{"transaction construction error"};
+
+        return tx;
+    }
+} // anonymous
+
+TEST(JsonSerialization, MinerTransaction)
+{
+    cryptonote::account_base acct;
+    acct.generate();
+    const auto miner_tx = make_miner_transaction(acct.get_keys().m_account_address);
+
+    crypto::hash tx_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(miner_tx, tx_hash));
+
+    rapidjson::Document doc;
+    cryptonote::json::toJsonValue(doc, miner_tx, doc);
+
+    cryptonote::transaction miner_tx_copy;
+    cryptonote::json::fromJsonValue(doc, miner_tx_copy);
+
+    crypto::hash tx_copy_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(miner_tx_copy, tx_copy_hash));
+    EXPECT_EQ(tx_hash, tx_copy_hash);
+
+    cryptonote::blobdata tx_bytes{};
+    cryptonote::blobdata tx_copy_bytes{};
+
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(miner_tx, tx_bytes));
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(miner_tx_copy, tx_copy_bytes));
+
+    EXPECT_EQ(tx_bytes, tx_copy_bytes);
+}
+
+TEST(JsonSerialization, RegularTransaction)
+{
+    cryptonote::account_base acct1;
+    acct1.generate();
+
+    cryptonote::account_base acct2;
+    acct2.generate();
+
+    const auto miner_tx = make_miner_transaction(acct1.get_keys().m_account_address);
+    const auto tx = make_transaction(
+        acct1.get_keys(), {miner_tx}, {acct2.get_keys().m_account_address}, false, false
+    );
+
+    crypto::hash tx_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(tx, tx_hash));
+
+    rapidjson::Document doc;
+    cryptonote::json::toJsonValue(doc, tx, doc);
+
+    cryptonote::transaction tx_copy;
+    cryptonote::json::fromJsonValue(doc, tx_copy);
+
+    crypto::hash tx_copy_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(tx_copy, tx_copy_hash));
+    EXPECT_EQ(tx_hash, tx_copy_hash);
+
+    cryptonote::blobdata tx_bytes{};
+    cryptonote::blobdata tx_copy_bytes{};
+
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(tx, tx_bytes));
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(tx_copy, tx_copy_bytes));
+
+    EXPECT_EQ(tx_bytes, tx_copy_bytes);
+}
+
+TEST(JsonSerialization, RingctTransaction)
+{
+    cryptonote::account_base acct1;
+    acct1.generate();
+
+    cryptonote::account_base acct2;
+    acct2.generate();
+
+    const auto miner_tx = make_miner_transaction(acct1.get_keys().m_account_address);
+    const auto tx = make_transaction(
+        acct1.get_keys(), {miner_tx}, {acct2.get_keys().m_account_address}, true, false
+    );
+
+    crypto::hash tx_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(tx, tx_hash));
+
+    rapidjson::Document doc;
+    cryptonote::json::toJsonValue(doc, tx, doc);
+
+    cryptonote::transaction tx_copy;
+    cryptonote::json::fromJsonValue(doc, tx_copy);
+
+    crypto::hash tx_copy_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(tx_copy, tx_copy_hash));
+    EXPECT_EQ(tx_hash, tx_copy_hash);
+
+    cryptonote::blobdata tx_bytes{};
+    cryptonote::blobdata tx_copy_bytes{};
+
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(tx, tx_bytes));
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(tx_copy, tx_copy_bytes));
+
+    EXPECT_EQ(tx_bytes, tx_copy_bytes);
+}
+
+TEST(JsonSerialization, BulletproofTransaction)
+{
+    cryptonote::account_base acct1;
+    acct1.generate();
+
+    cryptonote::account_base acct2;
+    acct2.generate();
+
+    const auto miner_tx = make_miner_transaction(acct1.get_keys().m_account_address);
+    const auto tx = make_transaction(
+        acct1.get_keys(), {miner_tx}, {acct2.get_keys().m_account_address}, true, true
+    );
+
+    crypto::hash tx_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(tx, tx_hash));
+
+    rapidjson::Document doc;
+    cryptonote::json::toJsonValue(doc, tx, doc);
+
+    cryptonote::transaction tx_copy;
+    cryptonote::json::fromJsonValue(doc, tx_copy);
+
+    crypto::hash tx_copy_hash{};
+    ASSERT_TRUE(cryptonote::get_transaction_hash(tx_copy, tx_copy_hash));
+    EXPECT_EQ(tx_hash, tx_copy_hash);
+
+    cryptonote::blobdata tx_bytes{};
+    cryptonote::blobdata tx_copy_bytes{};
+
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(tx, tx_bytes));
+    ASSERT_TRUE(cryptonote::t_serializable_object_to_blob(tx_copy, tx_copy_bytes));
+
+    EXPECT_EQ(tx_bytes, tx_copy_bytes);
+}
+

--- a/tests/unit_tests/mlocker.cpp
+++ b/tests/unit_tests/mlocker.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include "misc_log_ex.h"
+#include "mlocker.h"
+
+#define BASE(data) (char*)(((uintptr_t)(data.get() + page_size - 1)) / page_size * page_size)
+
+TEST(mlocker, distinct_1)
+{
+  const size_t page_size = epee::mlocker::get_page_size();
+  ASSERT_TRUE(page_size > 0);
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  std::unique_ptr<char[]> data{new char[8 * page_size]};
+  epee::mlocker *m0 = new epee::mlocker(BASE(data), 1);
+  epee::mlocker *m1 = new epee::mlocker(BASE(data) + 2 * page_size, 1);
+  epee::mlocker *m2 = new epee::mlocker(BASE(data) + 3 * page_size, 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 3);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 3);
+  delete m0;
+  delete m1;
+  delete m2;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}
+
+TEST(mlocker, distinct_full_page)
+{
+  const size_t page_size = epee::mlocker::get_page_size();
+  ASSERT_TRUE(page_size > 0);
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  std::unique_ptr<char[]> data{new char[8 * page_size]};
+  epee::mlocker *m0 = new epee::mlocker(BASE(data), page_size);
+  epee::mlocker *m1 = new epee::mlocker(BASE(data) + 2 * page_size, page_size);
+  epee::mlocker *m2 = new epee::mlocker(BASE(data) + 3 * page_size, page_size);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 3);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 3);
+  delete m0;
+  delete m1;
+  delete m2;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}
+
+TEST(mlocker, identical)
+{
+  const size_t page_size = epee::mlocker::get_page_size();
+  ASSERT_TRUE(page_size >= 32);
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  std::unique_ptr<char[]> data{new char[8 * page_size]};
+  epee::mlocker *m0 = new epee::mlocker(BASE(data) + page_size, 32);
+  epee::mlocker *m1 = new epee::mlocker(BASE(data) + page_size, 32);
+  epee::mlocker *m2 = new epee::mlocker(BASE(data) + page_size, 32);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 3);
+  delete m1;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 2);
+  delete m0;
+  delete m2;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}
+
+TEST(mlocker, overlapping_small)
+{
+  const size_t page_size = epee::mlocker::get_page_size();
+  ASSERT_TRUE(page_size >= 64);
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  std::unique_ptr<char[]> data{new char[8 * page_size]};
+  epee::mlocker *m0 = new epee::mlocker(BASE(data), 32);
+  epee::mlocker *m1 = new epee::mlocker(BASE(data) + 16, 32);
+  epee::mlocker *m2 = new epee::mlocker(BASE(data) + 8, 32);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 3);
+  delete m1;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 2);
+  delete m2;
+  delete m0;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}
+
+TEST(mlocker, multi_page)
+{
+  const size_t page_size = epee::mlocker::get_page_size();
+  ASSERT_TRUE(page_size > 0);
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  std::unique_ptr<char[]> data{new char[8 * page_size]};
+  epee::mlocker *m0 = new epee::mlocker(BASE(data) + page_size, page_size * 3);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 3);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 1);
+  epee::mlocker *m1 = new epee::mlocker(BASE(data) + page_size * 7, page_size);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 4);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 2);
+  delete m0;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 1);
+  delete m1;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}
+
+TEST(mlocker, cross_page)
+{
+  const size_t page_size = epee::mlocker::get_page_size();
+  ASSERT_TRUE(page_size > 32);
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  std::unique_ptr<char[]> data{new char[2 * page_size]};
+  epee::mlocker *m0 = new epee::mlocker(BASE(data) + page_size - 1, 2);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 2);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 1);
+  delete m0;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}
+
+TEST(mlocker, redundant)
+{
+  const size_t page_size = epee::mlocker::get_page_size();
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  std::unique_ptr<char[]> data{new char[2 * page_size]};
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+  epee::mlocker *m0 = new epee::mlocker(BASE(data), 32);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 1);
+  epee::mlocker *m1 = new epee::mlocker(BASE(data), 32);
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 2);
+  delete m1;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 1);
+  delete m0;
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}
+
+TEST(mlocker, mlocked)
+{
+  const size_t base_pages = epee::mlocker::get_num_locked_pages();
+  const size_t base_objects = epee::mlocker::get_num_locked_objects();
+  {
+    struct Foo { uint64_t u; };
+    epee::mlocked<Foo> l;
+    ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 1);
+    ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 1);
+  }
+  ASSERT_EQ(epee::mlocker::get_num_locked_pages(), base_pages + 0);
+  ASSERT_EQ(epee::mlocker::get_num_locked_objects(), base_objects + 0);
+}

--- a/tests/unit_tests/mnemonics.cpp
+++ b/tests/unit_tests/mnemonics.cpp
@@ -27,6 +27,8 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gtest/gtest.h"
+#include "wipeable_string.h"
+#include "mnemonics/language_base.h"
 #include "mnemonics/electrum-words.h"
 #include "crypto/crypto.h"
 #include <stdlib.h>
@@ -74,14 +76,16 @@ namespace
   void test_language(const Language::Base &language)
   {
     const std::vector<std::string> &word_list = language.get_word_list();
-    std::string seed = "", return_seed = "";
+    epee::wipeable_string w_seed = "", w_return_seed = "";
+    std::string seed, return_seed;
     // Generate a random seed without checksum
     crypto::secret_key randkey;
     for (size_t ii = 0; ii < sizeof(randkey); ++ii)
     {
       randkey.data[ii] = rand();
     }
-    crypto::ElectrumWords::bytes_to_words(randkey, seed, language.get_language_name());
+    crypto::ElectrumWords::bytes_to_words(randkey, w_seed, language.get_language_name());
+    seed = std::string(w_seed.data(), w_seed.size());
     // remove the checksum word
     const char *space = strrchr(seed.c_str(), ' ');
     ASSERT_TRUE(space != NULL);
@@ -103,7 +107,8 @@ namespace
     ASSERT_STREQ(language.get_language_name().c_str(), language_name.c_str());
 
     // Convert the secret key back to seed
-    crypto::ElectrumWords::bytes_to_words(key, return_seed, language.get_language_name());
+    crypto::ElectrumWords::bytes_to_words(key, w_return_seed, language.get_language_name());
+    return_seed = std::string(w_return_seed.data(), w_return_seed.size());
     ASSERT_EQ(true, res);
     std::cout << "Returned seed:\n";
     std::cout << return_seed << std::endl;
@@ -126,8 +131,9 @@ namespace
     std::cout << "Detected language: " << language_name << std::endl;
     ASSERT_STREQ(language.get_language_name().c_str(), language_name.c_str());
 
-    return_seed = "";
-    crypto::ElectrumWords::bytes_to_words(key, return_seed, language.get_language_name());
+    w_return_seed = "";
+    crypto::ElectrumWords::bytes_to_words(key, w_return_seed, language.get_language_name());
+    return_seed = std::string(w_return_seed.data(), w_return_seed.size());
     ASSERT_EQ(true, res);
     std::cout << "Returned seed:\n";
     std::cout << return_seed << std::endl;
@@ -201,4 +207,18 @@ TEST(mnemonics, language_detection_with_bad_checksum)
     res = crypto::ElectrumWords::words_to_bytes(base_seed + " " + real_checksum, key, language_name);
     ASSERT_EQ(true, res);
     ASSERT_STREQ(language_name.c_str(), "Português");
+}
+
+TEST(mnemonics, utf8prefix)
+{
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("foo"), 0) == "");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("foo"), 1) == "f");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("foo"), 2) == "fo");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("foo"), 3) == "foo");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("foo"), 4) == "foo");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("æon"), 0) == "");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("æon"), 1) == "æ");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("æon"), 2) == "æo");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("æon"), 3) == "æon");
+  ASSERT_TRUE(Language::utf8prefix(epee::wipeable_string("æon"), 4) == "æon");
 }

--- a/tests/unit_tests/multisig.cpp
+++ b/tests/unit_tests/multisig.cpp
@@ -61,10 +61,13 @@ static void make_wallet(unsigned int idx, tools::wallet2 &wallet)
 
   try
   {
-    wallet.init("");
+    wallet.init(false, "");
     wallet.set_subaddress_lookahead(1, 1);
     wallet.generate("", "", spendkey, true, false);
     ASSERT_TRUE(test_addresses[idx].address == wallet.get_account().get_public_address_str(cryptonote::TESTNET));
+    wallet.decrypt_keys("");
+    ASSERT_TRUE(test_addresses[idx].spendkey == epee::string_tools::pod_to_hex(wallet.get_account().get_keys().m_spend_secret_key));
+    wallet.encrypt_keys("");
   }
   catch (const std::exception &e)
   {
@@ -83,8 +86,12 @@ static void make_M_2_wallet(tools::wallet2 &wallet0, tools::wallet2 &wallet1, un
   std::vector<crypto::secret_key> sk0(1), sk1(1);
   std::vector<crypto::public_key> pk0(1), pk1(1);
 
+  wallet0.decrypt_keys("");
   std::string mi0 = wallet0.get_multisig_info();
+  wallet0.encrypt_keys("");
+  wallet1.decrypt_keys("");
   std::string mi1 = wallet1.get_multisig_info();
+  wallet1.encrypt_keys("");
 
   ASSERT_TRUE(tools::wallet2::verify_multisig_info(mi1, sk0[0], pk0[0]));
   ASSERT_TRUE(tools::wallet2::verify_multisig_info(mi0, sk1[0], pk1[0]));
@@ -118,9 +125,15 @@ static void make_M_3_wallet(tools::wallet2 &wallet0, tools::wallet2 &wallet1, to
   std::vector<crypto::secret_key> sk0(2), sk1(2), sk2(2);
   std::vector<crypto::public_key> pk0(2), pk1(2), pk2(2);
 
+  wallet0.decrypt_keys("");
   std::string mi0 = wallet0.get_multisig_info();
+  wallet0.encrypt_keys("");
+  wallet1.decrypt_keys("");
   std::string mi1 = wallet1.get_multisig_info();
+  wallet1.encrypt_keys("");
+  wallet2.decrypt_keys("");
   std::string mi2 = wallet2.get_multisig_info();
+  wallet2.encrypt_keys("");
 
   ASSERT_TRUE(tools::wallet2::verify_multisig_info(mi1, sk0[0], pk0[0]));
   ASSERT_TRUE(tools::wallet2::verify_multisig_info(mi2, sk0[1], pk0[1]));

--- a/tests/unit_tests/ringdb.cpp
+++ b/tests/unit_tests/ringdb.cpp
@@ -39,25 +39,29 @@
 #include "crypto/crypto.h"
 #include "crypto/random.h"
 #include "crypto/chacha.h"
+#include "ringct/rctOps.h"
+#include "cryptonote_basic/cryptonote_basic.h"
 #include "wallet/ringdb.h"
 
 static crypto::chacha_key generate_chacha_key()
 {
-  uint8_t key[CHACHA_KEY_SIZE];
-  crypto::rand(CHACHA_KEY_SIZE, key);
   crypto::chacha_key chacha_key;
-  memcpy(&chacha_key, key, CHACHA_KEY_SIZE);
+  uint64_t password = crypto::rand<uint64_t>();
+  crypto::generate_chacha_key(std::string((const char*)&password, sizeof(password)), chacha_key);
   return chacha_key;
 }
 
 static crypto::key_image generate_key_image()
 {
-  return crypto::rand<crypto::key_image>();
+  crypto::key_image key_image;
+  cryptonote::keypair keypair = cryptonote::keypair::generate(hw::get_device("default"));
+  crypto::generate_key_image(keypair.pub, keypair.sec, key_image);
+  return key_image;
 }
 
 static crypto::public_key generate_output()
 {
-  return crypto::rand<crypto::public_key>();
+  return rct::rct2pk(rct::scalarmultBase(rct::skGen()));
 }
 
 

--- a/tests/unit_tests/ringdb.cpp
+++ b/tests/unit_tests/ringdb.cpp
@@ -47,7 +47,7 @@ static crypto::chacha_key generate_chacha_key()
 {
   crypto::chacha_key chacha_key;
   uint64_t password = crypto::rand<uint64_t>();
-  crypto::generate_chacha_key(std::string((const char*)&password, sizeof(password)), chacha_key);
+  crypto::generate_chacha_key(std::string((const char*)&password, sizeof(password)), chacha_key, 1);
   return chacha_key;
 }
 

--- a/tests/unit_tests/ringdb.cpp
+++ b/tests/unit_tests/ringdb.cpp
@@ -76,13 +76,13 @@ public:
 private:
   std::string make_filename()
   {
-    boost::filesystem::path path = tools::get_default_data_dir();
-    path /= "fake";
+    boost::filesystem::path path =
+      boost::filesystem::temp_directory_path();
 #if defined(__MINGW32__) || defined(__MINGW__)
-    filename = tempnam(path.string().c_str(), "ringdb-test-");
+    filename = tempnam(path.string().c_str(), "aeon-ringdb-test-");
     EXPECT_TRUE(filename != NULL);
 #else
-    path /= "ringdb-test-XXXXXX";
+    path /= "aeon-ringdb-test-XXXXXX";
     filename = strdup(path.string().c_str());
     EXPECT_TRUE(mkdtemp(filename) != NULL);
 #endif

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -865,7 +865,7 @@ TEST(Serialization, portability_outputs)
     if(ciphertext.size() < prefix_size)
       return {};
     crypto::chacha_key key;
-    crypto::generate_chacha_key(&skey, sizeof(skey), key);
+    crypto::generate_chacha_key(&skey, sizeof(skey), key, 1);
     const crypto::chacha_iv &iv = *(const crypto::chacha_iv*)&ciphertext[0];
     std::string plaintext;
     plaintext.resize(ciphertext.size() - prefix_size);

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -671,8 +671,7 @@ TEST(Serialization, serializes_ringct_types)
 TEST(Serialization, portability_wallet)
 {
   const cryptonote::network_type nettype = cryptonote::MAINNET;
-  const bool restricted = false;
-  tools::wallet2 w(nettype, restricted);
+  tools::wallet2 w(nettype);
   const boost::filesystem::path wallet_file = unit_test::data_dir / "wallet_WmsMW3";
   string password = "test";
   bool r = false;

--- a/tests/unit_tests/wipeable_string.cpp
+++ b/tests/unit_tests/wipeable_string.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2018, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <boost/optional/optional.hpp>
+#include <string.h>
+#include "gtest/gtest.h"
+
+#include "misc_log_ex.h"
+#include "wipeable_string.h"
+
+TEST(wipeable_string, ctor)
+{
+  epee::wipeable_string s0;
+  ASSERT_EQ(s0.size(), 0);
+
+  epee::wipeable_string s1(std::string("foo"));
+  ASSERT_EQ(s1.size(), 3);
+  ASSERT_TRUE(!memcmp(s1.data(), "foo", s1.size()));
+
+  epee::wipeable_string s2(std::string("bar"));
+  ASSERT_EQ(s2.size(), 3);
+  ASSERT_TRUE(!memcmp(s2.data(), "bar", s2.size()));
+
+  epee::wipeable_string s3(std::string("quux"));
+  ASSERT_EQ(s3.size(), 4);
+  ASSERT_TRUE(!memcmp(s3.data(), "quux", s3.size()));
+}
+
+TEST(wipeable_string, wipe)
+{
+  epee::wipeable_string s0(std::string("foo"));
+  ASSERT_EQ(s0.size(), 3);
+  s0.wipe();
+  ASSERT_EQ(s0.size(), 3);
+  ASSERT_TRUE(!memcmp(s0.data(), "\0\0\0", 3));
+}
+
+TEST(wipeable_string, clear)
+{
+  epee::wipeable_string s0(std::string("foo"));
+  ASSERT_EQ(s0.size(), 3);
+  s0.clear();
+  ASSERT_EQ(s0.size(), 0);
+}
+
+TEST(wipeable_string, push_back)
+{
+  epee::wipeable_string s0(std::string("fo"));
+  ASSERT_EQ(s0.size(), 2);
+  s0.push_back('o');
+  ASSERT_EQ(s0.size(), 3);
+  ASSERT_TRUE(!memcmp(s0.data(), "foo", s0.size()));
+}
+
+TEST(wipeable_string, append_char)
+{
+  epee::wipeable_string s0(std::string("fo"));
+  ASSERT_EQ(s0.size(), 2);
+  s0 += 'o';
+  ASSERT_EQ(s0.size(), 3);
+  ASSERT_TRUE(!memcmp(s0.data(), "foo", s0.size()));
+}
+
+TEST(wipeable_string, append_string)
+{
+  epee::wipeable_string s0(std::string("foo"));
+  ASSERT_EQ(s0.size(), 3);
+  s0 += "bar";
+  ASSERT_EQ(s0.size(), 6);
+  ASSERT_TRUE(!memcmp(s0.data(), "foobar", s0.size()));
+}
+
+TEST(wipeable_string, empty)
+{
+  epee::wipeable_string s0;
+  ASSERT_TRUE(s0.empty());
+  s0.push_back(' ');
+  ASSERT_FALSE(s0.empty());
+  ASSERT_EQ(s0.pop_back(), ' ');
+  ASSERT_TRUE(s0.empty());
+}
+
+TEST(wipeable_string, pop_back)
+{
+  epee::wipeable_string s = "test";
+  ASSERT_EQ(s.size(), 4);
+  ASSERT_EQ(s.pop_back(), 't');
+  ASSERT_EQ(s.size(), 3);
+  ASSERT_TRUE(!memcmp(s.data(), "tes", s.size()));
+}
+
+TEST(wipeable_string, equal)
+{
+  epee::wipeable_string s0 = "foo";
+  epee::wipeable_string s1 = "bar";
+  epee::wipeable_string s0_2 = "foo";
+  ASSERT_TRUE(s0 == s0);
+  ASSERT_TRUE(s0 == s0_2);
+  ASSERT_TRUE(s1 == s1);
+  ASSERT_FALSE(s1 == s0);
+  ASSERT_FALSE(s1 == s0_2);
+}
+
+TEST(wipeable_string, not_equal)
+{
+  epee::wipeable_string s0 = "foo";
+  epee::wipeable_string s1 = "bar";
+  epee::wipeable_string s0_2 = "foo";
+  ASSERT_FALSE(s0 != s0);
+  ASSERT_FALSE(s0 != s0_2);
+  ASSERT_FALSE(s1 != s1);
+  ASSERT_TRUE(s1 != s0);
+  ASSERT_TRUE(s1 != s0_2);
+}
+
+static epee::wipeable_string trimmed(const char *s)
+{
+  epee::wipeable_string str(s);
+  str.trim();
+  return str;
+}
+
+TEST(wipeable_string, trim)
+{
+  ASSERT_TRUE(trimmed("") == "");
+  ASSERT_TRUE(trimmed(" ") == "");
+  ASSERT_TRUE(trimmed("  ") == "");
+  ASSERT_TRUE(trimmed("a") == "a");
+  ASSERT_TRUE(trimmed(" a") == "a");
+  ASSERT_TRUE(trimmed("  a") == "a");
+  ASSERT_TRUE(trimmed("a ") == "a");
+  ASSERT_TRUE(trimmed("a  ") == "a");
+  ASSERT_TRUE(trimmed(" a  ") == "a");
+  ASSERT_TRUE(trimmed("  a  ") == "a");
+  ASSERT_TRUE(trimmed("  ab  ") == "ab");
+  ASSERT_TRUE(trimmed("  a b  ") == "a b");
+  ASSERT_TRUE(trimmed("  a  b  ") == "a  b");
+}
+
+static bool check_split(const char *s, const std::vector<epee::wipeable_string> &v)
+{
+  epee::wipeable_string str(s);
+  std::vector<epee::wipeable_string> fields;
+  str.split(fields);
+  return v == fields;
+}
+
+TEST(wipeable_string, split)
+{
+  ASSERT_TRUE(check_split("", {}));
+  ASSERT_TRUE(check_split("foo", {"foo"}));
+  ASSERT_TRUE(check_split("  foo   ", {"foo"}));
+  ASSERT_TRUE(check_split("foo bar", {"foo", "bar"}));
+  ASSERT_TRUE(check_split("foo     bar", {"foo", "bar"}));
+  ASSERT_TRUE(check_split("foo     bar   baz", {"foo", "bar", "baz"}));
+  ASSERT_TRUE(check_split(" foo     bar   baz         ", {"foo", "bar", "baz"}));
+  ASSERT_TRUE(check_split("  foo     bar   baz", {"foo", "bar", "baz"}));
+  ASSERT_TRUE(check_split("foo     bar   baz ", {"foo", "bar", "baz"}));
+}
+
+TEST(wipeable_string, parse_hexstr)
+{
+  boost::optional<epee::wipeable_string> s;
+
+  ASSERT_EQ(boost::none, epee::wipeable_string("x").parse_hexstr());
+  ASSERT_EQ(boost::none, epee::wipeable_string("x0000000000000000").parse_hexstr());
+  ASSERT_EQ(boost::none, epee::wipeable_string("0000000000000000x").parse_hexstr());
+  ASSERT_EQ(boost::none, epee::wipeable_string("0").parse_hexstr());
+  ASSERT_EQ(boost::none, epee::wipeable_string("000").parse_hexstr());
+
+  ASSERT_TRUE((s = epee::wipeable_string("").parse_hexstr()));
+  ASSERT_EQ(*s, "");
+  ASSERT_TRUE((s = epee::wipeable_string("00").parse_hexstr()));
+  ASSERT_EQ(*s, epee::wipeable_string("", 1));
+  ASSERT_TRUE((s = epee::wipeable_string("41").parse_hexstr()));
+  ASSERT_EQ(*s, epee::wipeable_string("A"));
+  ASSERT_TRUE((s = epee::wipeable_string("414243").parse_hexstr()));
+  ASSERT_EQ(*s, epee::wipeable_string("ABC"));
+}

--- a/utils/conf/aeond.conf
+++ b/utils/conf/aeond.conf
@@ -1,5 +1,6 @@
 # Configuration for aeond
 # Syntax: any command line option may be specified as 'clioptionname=value'.
+#         Boolean options such as 'no-igd' are specified as 'no-igd=1'.
 # See 'aeond --help' for all available options.
 
 data-dir=/var/lib/aeon


### PR DESCRIPTION
I had a private chat with @camthegeek and made some arguments which can be summarized as follows:

- Merging upstream patches is in itself not a too difficult task, but it's also quite easy to make mistakes since there are many instances of merge conflicts. Also, some patches require adapting the changes to Aeon (e.g. replacing string literals).

- While I do feel happy to see people's willingness to contribute to the effort of merging upstream patches, I'd necessarily feel uneasy about blindly trusting the work offered by them, especially when they seem to have relatively limited experience with the Monero codebase and development in general. Therefore, I'd have to redo the same merging task myself again and compare the result with the offered one in order to be sure that the patches were merged properly. This seems wasteful since the same work is repeated by two people.

- I know this sounds arrogant, but I believe I'm the most familiar with the codebase and thus the most suitable for the task of merging upstream patches among the Aeon community members. For the time being, I'll be able to keep working on merging upstream patches on a regular basis; i.e. I'll make sure to submit the next upstream merge PR as soon as possible after the previous one gets merged. If the situation around me changes and I become unable to keep working on Aeon in the future, I'll announce as such.

- I don't mean to discourage people from working on the development. One important way of contributing (in addition to testing) is to review the upstream merge PRs and find out any mistakes I make. Such reviewing will also be very helpful for familiarizing yourself more with the codebase. More people becoming familiar with the codebase is crucially important since the development shouldn't be dependent on a small number of people who can suddenly disappear for various reasons (car accident, illness, etc).

-----

That said, this PR replicates the work done by @camthegeek in #100:

This pull request merges upstream patches after https://github.com/monero-project/monero/pull/4129 which is the last one included in #90. This PR includes upstream PRs from https://github.com/monero-project/monero/pull/3528 merged on August 15 up to https://github.com/monero-project/monero/pull/3999 merged on August 24:

- https://github.com/monero-project/monero/pull/3528
- https://github.com/monero-project/monero/pull/4020
- https://github.com/monero-project/monero/pull/4024
- https://github.com/monero-project/monero/pull/4089
- https://github.com/monero-project/monero/pull/4090
- https://github.com/monero-project/monero/pull/4103
- https://github.com/monero-project/monero/pull/4106
- https://github.com/monero-project/monero/pull/4136
- https://github.com/monero-project/monero/pull/4137
- https://github.com/monero-project/monero/pull/4138
- https://github.com/monero-project/monero/pull/4148
- https://github.com/monero-project/monero/pull/4150
- https://github.com/monero-project/monero/pull/4153
- https://github.com/monero-project/monero/pull/4158
- https://github.com/monero-project/monero/pull/4161
- https://github.com/monero-project/monero/pull/4164
- https://github.com/monero-project/monero/pull/4165
- https://github.com/monero-project/monero/pull/4166
- https://github.com/monero-project/monero/pull/4170
- https://github.com/monero-project/monero/pull/4171
- https://github.com/monero-project/monero/pull/4172
- https://github.com/monero-project/monero/pull/4173
- https://github.com/monero-project/monero/pull/4174
- https://github.com/monero-project/monero/pull/4177
- https://github.com/monero-project/monero/pull/4186
- https://github.com/monero-project/monero/pull/4188
- https://github.com/monero-project/monero/pull/4192
- https://github.com/monero-project/monero/pull/4193
- https://github.com/monero-project/monero/pull/4194
- https://github.com/monero-project/monero/pull/4195
- https://github.com/monero-project/monero/pull/4196
- https://github.com/monero-project/monero/pull/4191
- https://github.com/monero-project/monero/pull/4131
- https://github.com/monero-project/monero/pull/4179
- https://github.com/monero-project/monero/pull/4200
- https://github.com/monero-project/monero/pull/4202
- https://github.com/monero-project/monero/pull/4204
- https://github.com/monero-project/monero/pull/4207
- https://github.com/monero-project/monero/pull/4210
- https://github.com/monero-project/monero/pull/4224
- https://github.com/monero-project/monero/pull/4225
- https://github.com/monero-project/monero/pull/4231
- https://github.com/monero-project/monero/pull/4240
- https://github.com/monero-project/monero/pull/4242
- https://github.com/monero-project/monero/pull/4247
- https://github.com/monero-project/monero/pull/4249
- https://github.com/monero-project/monero/pull/3999

Some noteworthy remarks:

- The gamma output selection introduced in https://github.com/monero-project/monero/pull/3528 is only effective for RingCT outputs, so it has no effect for Aeon currently. FYI, this PR introduced a flaw in Monero that got later fixed in https://github.com/monero-project/monero/pull/4697.

- An optional flag `--kdf-rounds` was added to the wallet CLI/RPC in https://github.com/monero-project/monero/pull/4103 which is meant to be a protection against brute forcing passwords.

- https://github.com/monero-project/monero/pull/4170 adds [`get_address_index`](https://www.getmonero.org/resources/developer-guides/wallet-rpc.html#get_address_index) command to the wallet RPC.

- https://github.com/monero-project/monero/pull/4171 allows you to filter the wallet RPC `getbalance` response by `address_indices`.

- https://github.com/monero-project/monero/pull/4188 adds `set_tx_key` command to the wallet CLI that allows you to import tx keys generated by some other 3rd party wallet software.

- https://github.com/monero-project/monero/pull/4131 improves the security of the wallet CLI by keeping the wallet secret keys encrypted when the wallet file is loaded on memory and decrypting them only when needed for signing.

- https://github.com/monero-project/monero/pull/4242 adds [`refresh`](https://www.getmonero.org/resources/developer-guides/wallet-rpc.html#refresh) command to the wallet RPC.

- https://github.com/monero-project/monero/pull/3999 was already cherry picked previously in #30 which got merged before https://github.com/monero-project/monero/pull/3999 got merged in Monero. https://github.com/monero-project/monero/pull/3999 was then later replaced by force push, introducing some inconsistency which is resolved here by cherry picking again.
