### PR TITLE
blockchain: enforce 10 block age for spending outputs /monero#5882

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -141,6 +141,7 @@
 
 #define HF_VERSION_ALLOW_V1_BORROMEAN           8
 #define HF_VERSION_FIXED_RING_SIZE              8
+#define HF_VERSION_ENFORCE_MIN_AGE              8
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2614,6 +2614,9 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
   const auto waiter_guard = epee::misc_utils::create_scope_leave_handler([&]() { waiter.wait(&tpool); });
   int threads = tpool.get_max_concurrency();
 
+  uint64_t max_used_block_height = 0;
+  if (!pmax_used_block_height)
+    pmax_used_block_height = &max_used_block_height;
   for (const auto& txin : tx.vin)
   {
     // make sure output being spent is of type txin_to_key, rather than
@@ -2703,6 +2706,13 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
   }
   if (tx_v1_0 && threads > 1)
     waiter.wait(&tpool);
+
+  // enforce min output age
+  if (hf_version >= HF_VERSION_ENFORCE_MIN_AGE)
+  {
+    CHECK_AND_ASSERT_MES(*pmax_used_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE <= m_db->height(),
+        false, "Transaction spends at least one output which is too young");
+  }
 
   if (tx_v1_0)
   {

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -204,6 +204,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(gen_rct_tx_pre_rct_increase_vin_and_fee);
     GENERATE_AND_PLAY(gen_rct_tx_pre_rct_altered_extra);
     GENERATE_AND_PLAY(gen_rct_tx_rct_altered_extra);
+    GENERATE_AND_PLAY(gen_rct_tx_uses_output_too_early);
 
     GENERATE_AND_PLAY(gen_multisig_tx_valid_22_1_2);
     GENERATE_AND_PLAY(gen_multisig_tx_valid_22_1_2_many_inputs);

--- a/tests/core_tests/rct.h
+++ b/tests/core_tests/rct.h
@@ -69,6 +69,10 @@ struct gen_rct_tx_validation_base : public test_chain_unit_base
     return true;
   }
 
+  bool generate_with_full(std::vector<test_event_entry>& events, const int *out_idx, int mixin,
+      uint64_t amount_paid, size_t second_rewind, uint8_t last_version, bool valid,
+      const std::function<void(std::vector<cryptonote::tx_source_entry> &sources, std::vector<cryptonote::tx_destination_entry> &destinations)> &pre_tx,
+      const std::function<void(cryptonote::transaction &tx)> &post_tx) const;
   bool generate_with(std::vector<test_event_entry>& events, const int *out_idx, int mixin,
       uint64_t amount_paid, bool valid,
       const std::function<void(std::vector<cryptonote::tx_source_entry> &sources, std::vector<cryptonote::tx_destination_entry> &destinations)> &pre_tx,
@@ -262,3 +266,13 @@ struct gen_rct_tx_rct_altered_extra : public gen_rct_tx_validation_base
 };
 template<> struct get_test_options<gen_rct_tx_rct_altered_extra>: public get_test_options<gen_rct_tx_validation_base> {};
 
+struct gen_rct_tx_uses_output_too_early : public gen_rct_tx_validation_base
+{
+  bool generate(std::vector<test_event_entry>& events) const;
+};
+template<> struct get_test_options<gen_rct_tx_uses_output_too_early> {
+  const cryptonote::test_options::hard_fork_t hard_forks[4] = { {1, 0, 0}, {2, 1, 0}, {HF_VERSION_ALLOW_RCT, 65, 0}, {0, 0, 0} };
+  const cryptonote::test_options test_options = {
+    hard_forks, 0
+  };
+};


### PR DESCRIPTION
Some custom wallet code apparently ignores this, which causes users
of that code to be fingerprinted