### PR TITLE
blockchain: keep block template timestamp not above recent median /mo…

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1219,7 +1219,9 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
     if (!memcmp(&miner_address, &m_btc_address, sizeof(cryptonote::account_public_address)) && m_btc_nonce == ex_nonce
       && m_btc_pool_cookie == m_tx_pool.cookie() && m_btc.prev_id == get_tail_id()) {
       MDEBUG("Using cached template");
-      m_btc.timestamp = time(NULL); // update timestamp unconditionally
+      const uint64_t now = time(NULL);
+      if (m_btc.timestamp < now) // ensures it can't get below the median of the last few blocks
+        m_btc.timestamp = now;
       b = m_btc;
       diffic = m_btc_difficulty;
       expected_reward = m_btc_expected_reward;


### PR DESCRIPTION
…nero#5902

Such a template would yield an invalid block, though would require
an attacker to have mined a long blockchain with drifting times
(assuming the miner's clock is roughly correct)

Fixed by crCr62U0