### PR TITLE
GCC 9.1 fixes /monero#5613+#5865

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,8 +650,11 @@ else()
     add_cxx_flag_if_supported(-fstack-clash-protection CXX_SECURITY_FLAGS)
   endif()
 
-  add_c_flag_if_supported(-mmitigate-rop C_SECURITY_FLAGS)
-  add_cxx_flag_if_supported(-mmitigate-rop CXX_SECURITY_FLAGS)
+  # Removed in GCC 9.1 (or before ?), but still accepted, so spams the output
+  if (NOT (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 9.1))
+    add_c_flag_if_supported(-mmitigate-rop C_SECURITY_FLAGS)
+    add_cxx_flag_if_supported(-mmitigate-rop CXX_SECURITY_FLAGS)
+  endif()
 
   # linker
   if (NOT WIN32)

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -257,6 +257,11 @@ namespace net_utils
                                m_current_speed_up(0)
     {}
 
+    connection_context_base(const connection_context_base& a): connection_context_base()
+    {
+      set_details(a.m_connection_id, a.m_remote_address, a.m_is_income);
+    }
+
     connection_context_base& operator=(const connection_context_base& a)
     {
       set_details(a.m_connection_id, a.m_remote_address, a.m_is_income);

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -94,6 +94,18 @@ namespace hw {
       AKout = keys.AKout;
     }
 
+    ABPkeys &ABPkeys::operator=(const ABPkeys& keys) {
+      if (&keys == this)
+        return *this;
+      Aout = keys.Aout;
+      Bout = keys.Bout;
+      is_subaddress = keys.is_subaddress;
+      index = keys.index;
+      Pout = keys.Pout;
+      AKout = keys.AKout;
+      return *this;
+    }
+
     bool Keymap::find(const rct::key& P, ABPkeys& keys) const {
       size_t sz = ABP.size();
       for (size_t i=0; i<sz; i++) {

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -68,6 +68,7 @@ namespace hw {
         ABPkeys(const rct::key& A, const rct::key& B, const bool is_subaddr,  size_t index, const rct::key& P,const rct::key& AK);
         ABPkeys(const ABPkeys& keys) ;
         ABPkeys() {index=0;is_subaddress=false;}
+        ABPkeys &operator=(const ABPkeys &keys);
     };
 
     class Keymap {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3694,7 +3694,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
   }
   success_msg_writer() << "**********************************************************************";
 
-  return std::move(password);
+  return password;
 }
 //----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
@@ -3741,7 +3741,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
   }
 
 
-  return std::move(password);
+  return password;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -3778,7 +3778,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
     return {};
   }
 
-  return std::move(password);
+  return password;
 }
 //----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::program_options::variables_map& vm,
@@ -3831,7 +3831,7 @@ boost::optional<epee::wipeable_string> simple_wallet::new_wallet(const boost::pr
     return {};
   }
 
-  return std::move(password);
+  return password;
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::open_wallet(const boost::program_options::variables_map& vm)


### PR DESCRIPTION
https://github.com/monero-project/monero/pull/5613
https://github.com/monero-project/monero/pull/5865

Two of the five total commits https://github.com/monero-project/monero/pull/5613/commits/2cbe75661cb957f7be409a9e22df97d96329c5c8 and https://github.com/monero-project/monero/pull/5865/commits/11f13da8b48d9b9dffc036c2fdf862607fbd3edc were omitted due to the Aeon codebase not keeping up with Monero's recent updates.

Also, the second commit https://github.com/monero-project/monero/pull/5613/commits/35c20c4332b9483f0e4c60f244e44508e5fef69b was adapted so that nonexistent fields (`connection_context_base::m_ssl` and `ABPkeys::is_change_address` and `ABPkeys::additional_key`) are removed.

I'm leaving links to relevant upstream PRs that are to be taken in the future to hint the eventual patch creator (likely myself) that additional care is needed:

- https://github.com/monero-project/monero/pull/4988
- https://github.com/monero-project/monero/pull/5091
- https://github.com/monero-project/monero/pull/4054
- https://github.com/monero-project/monero/pull/5132
- https://github.com/monero-project/monero/pull/5374
- https://github.com/monero-project/monero/pull/4903
