### PR TITLE
db_lmdb: invoke migration from 4 to 5

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -4713,6 +4713,8 @@ void BlockchainLMDB::migrate(const uint32_t oldversion)
     migrate_2_3();
   if (oldversion < 4)
     migrate_3_4();
+  if (oldversion < 5)
+    migrate_4_5();
 }
 
 }  // namespace cryptonote


### PR DESCRIPTION
This bit was forgotten in https://github.com/aeonix/aeon/pull/108/commits/5bce3a1db0e1c58f5103980859eb03580329b324 when the added code `if (oldversion < 4) migrate_3_4();` in the original PR https://github.com/monero-project/monero/pull/5124 already existed in Aeon's code. This shows again the importance of double checking the correctness when taking upstream patches...
