### PR TITLE
wallet2_api: fix generating new wallet in the GUI /monero#4621

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -769,7 +769,7 @@ bool WalletImpl::setPassword(const std::string &password)
 {
     clearStatus();
     try {
-        m_wallet->rewrite(m_wallet->get_wallet_file(), password);
+        m_wallet->change_password(m_wallet->get_wallet_file(), m_password, password);
         m_password = password;
     } catch (const std::exception &e) {
         setStatusError(e.what());


### PR DESCRIPTION
It was creating a new wallet without a password first (this should
be fixed), then not changing the password correctly

https://github.com/monero-project/monero/pull/4621
