### PR TITLE
Fixed missing return value in once_a_time class on windows /monero#5113

### DIFF
--- a/contrib/epee/include/math_helper.h
+++ b/contrib/epee/include/math_helper.h
@@ -244,6 +244,7 @@ namespace math_helper
       present = present << 32;
       present |= fileTime.dwLowDateTime;
       present /= 10;  // mic-sec
+      return present;
 #else
       struct timeval tv;
       gettimeofday(&tv, NULL);


### PR DESCRIPTION
https://github.com/monero-project/monero/pull/5113