### PR TITLE
workflows: upload artifacts for easier release binary making

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,30 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+        fetch-depth: 0
     - name: install dependencies
       run: HOMEBREW_NO_AUTO_UPDATE=1  brew install boost openssl zmq libpgm miniupnpc ldns expat libunwind-headers protobuf
     - name: fetch zmq.hpp
       run: brew tap osrf/simulation && brew install cppzmq
     - name: build
-      run: make -j3
+      run: USE_SINGLE_BUILDDIR=1 make release-static -j3
+    - name: archive
+      run: |
+        export ARTIFACT_NAME="aeon-mac-x64-$(git describe --tags)"
+        mkdir $ARTIFACT_NAME
+        cp bin/* $ARTIFACT_NAME
+        tar cvzf $ARTIFACT_NAME.tar.bz2 $ARTIFACT_NAME
+        echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+      working-directory: build/release
+    - name: SHA256 checksum
+      run: openssl sha256 ${{ env.ARTIFACT_NAME }}.tar.bz2
+      working-directory: build/release
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.ARTIFACT_NAME }}.tar.bz2
+        path: build/release/${{ env.ARTIFACT_NAME }}.tar.bz2
+    - name: upload to transfer.sh
+      run: curl --upload-file build/release/${{ env.ARTIFACT_NAME }}.tar.bz2 https://transfer.sh/${{ env.ARTIFACT_NAME }}.tar.bz2
 
   build-windows:
     runs-on: windows-latest
@@ -25,12 +43,30 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+        fetch-depth: 0
     - uses: eine/setup-msys2@v2
       with:
         update: true
-        install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-protobuf-c git
+        install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-protobuf-c git zip curl
     - name: build
-      run: make release-static-win64 -j2
+      run: USE_SINGLE_BUILDDIR=1 make release-static-win64 -j2
+    - name: archive
+      run: |
+        export ARTIFACT_NAME="aeon-win-x64-$(git describe --tags)"
+        mkdir $ARTIFACT_NAME
+        cp bin/* $ARTIFACT_NAME
+        zip -r9 $ARTIFACT_NAME.zip $ARTIFACT_NAME
+        echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+      working-directory: build/release
+    - name: SHA256 checksum
+      run: openssl sha256 ${{ env.ARTIFACT_NAME }}.zip
+      working-directory: build/release
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.ARTIFACT_NAME }}.zip
+        path: build/release/${{ env.ARTIFACT_NAME }}.zip
+    - name: upload to transfer.sh
+      run: curl --upload-file build/release/${{ env.ARTIFACT_NAME }}.zip https://transfer.sh/${{ env.ARTIFACT_NAME }}.zip
 
   build-ubuntu:
     runs-on: ubuntu-latest
@@ -38,6 +74,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+        fetch-depth: 0
     - name: remove bundled boost
       run: sudo rm -rf /usr/local/share/boost
     - name: set apt conf
@@ -50,7 +87,24 @@ jobs:
     - name: install monero dependencies
       run: sudo apt -y install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libnorm-dev libpgm-dev
     - name: build
-      run: make -j3
+      run: USE_SINGLE_BUILDDIR=1 make release-static -j3
+    - name: archive
+      run: |
+        export ARTIFACT_NAME="aeon-linux-x64-$(git describe --tags)"
+        mkdir $ARTIFACT_NAME
+        cp bin/* $ARTIFACT_NAME
+        tar cvzf $ARTIFACT_NAME.tar.bz2 $ARTIFACT_NAME
+        echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+      working-directory: build/release
+    - name: SHA256 checksum
+      run: openssl sha256 ${{ env.ARTIFACT_NAME }}.tar.bz2
+      working-directory: build/release
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.ARTIFACT_NAME }}.tar.bz2
+        path: build/release/${{ env.ARTIFACT_NAME }}.tar.bz2
+    - name: upload to transfer.sh
+      run: curl --upload-file build/release/${{ env.ARTIFACT_NAME }}.tar.bz2 https://transfer.sh/${{ env.ARTIFACT_NAME }}.tar.bz2
 
   libwallet-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since the rebase in 2018, I've been responsible for producing release binaries for all the releases so far (v0.12.x, v0.13.x, v0.14.x). The work of building the code itself is not that difficult since we ensure that the code builds fine via Continuous Integration (CI), but somehow it often took me quite some time to produce all the binaries (CLI & GUI for Mac / Win / Linux), especially for the GUI, mainly because releases happen rather intermittently (sometimes after almost a year) and some update in the Operating System can change the version of some packaged libraries (in particular, Qt and Boost in MinGW) which can cause some unexpected issues while building.

Here I propose to change this: I'd rather use binaries produced by the GitHub Actions CI directly as release binaries. This way may feel uneasy to someone who worries about the possibility of GitHub inserting some malicious code into the binary. My response to this concern is: **I could be doing the same thing already, and if you're this kind of paranoia, you should build binary yourself**. I'm comfortable trusting GitHub not doing something malicious for us, the AEON community, especially when it's so tiny in market cap. To me personally, the benefit of not having to spend so much time on producing release binaries far outweighs the negligible chance of GitHub going rogue, considering the long-term viability.
