### PR TITLE
Windows build: fix narrowing error for WaitForSingleObject monero/#8349

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -179,7 +179,7 @@ namespace epee
 #else
       while (m_run.load(std::memory_order_relaxed))
       {
-        int retval = ::WaitForSingleObject(::GetStdHandle(STD_INPUT_HANDLE), 100);
+        DWORD retval = ::WaitForSingleObject(::GetStdHandle(STD_INPUT_HANDLE), 100);
         switch (retval)
         {
           case WAIT_FAILED:


### PR DESCRIPTION
`WaitForSingleObject` returns a `DWORD`, not an int, so assign `retval` as such and it should fix the error.